### PR TITLE
Encode/Decode datetime objects

### DIFF
--- a/snappiershot/serializers/json.py
+++ b/snappiershot/serializers/json.py
@@ -167,7 +167,7 @@ class JsonSerializer(json.JSONEncoder):
             }
 
         if isinstance(value, datetime.timedelta):
-            # Encode as total seconds, float
+            # Encode as total seconds, float (fractional part encodes microseconds)
             return {
                 DATETIME_KEY: DatetimeType.TIMEDELTA.value,
                 DATETIME_VALUE_KEY: value.total_seconds(),

--- a/tests/test_serializers/test_json.py
+++ b/tests/test_serializers/test_json.py
@@ -162,6 +162,7 @@ def test_round_trip():
             2020, 8, 9, 10, 11, 12, 13, tzinfo=datetime.timezone.utc
         ),
         "datetime_without_tz": datetime.datetime(2020, 8, 9, 10, 11, 12, 13),
+        "timedelta": datetime.timedelta(seconds=12, microseconds=13),
     }
 
     # Act


### PR DESCRIPTION
Adds support to the JSON en/decoder classes for custom encoding of datetime types

Types now supported:
- datetime.datetime (with time zone information)
- datetime.datetime (without time zone information)
- datetime.date
- datetime.time
- datetime.timedelta

Follows a similar approach to the existing custom dictionary-based encoded used for complex numeric types

Closes #21 