### PR TITLE
Bug Fix -- Partial File Writing

### DIFF
--- a/snappiershot/snapshot.py
+++ b/snappiershot/snapshot.py
@@ -369,14 +369,20 @@ class _SnapshotFile:
         if not self._changed_flag:
             return
         if self._snapshot_file.suffix == ".json":
-            with self._snapshot_file.open("w") as snapshot_file:
-                json.dump(
-                    obj=self._file_contents,
-                    fp=snapshot_file,
-                    cls=JsonSerializer,
-                    indent=self.config.json_indentation,
-                    sort_keys=True,
-                )
+            temporary_output_file = self._snapshot_file.with_suffix(".temp")
+            try:
+                with temporary_output_file.open("w") as snapshot_file:
+                    json.dump(
+                        obj=self._file_contents,
+                        fp=snapshot_file,
+                        cls=JsonSerializer,
+                        indent=self.config.json_indentation,
+                        sort_keys=True,
+                    )
+                temporary_output_file.rename(self._snapshot_file)
+            finally:
+                if temporary_output_file.exists():
+                    temporary_output_file.unlink()
         else:  # pragma: no cover
             raise ValueError(
                 f"Unsupported snapshot file format: {self._snapshot_file.suffix}"

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -381,3 +381,21 @@ class TestSnapshotFile:
         assert snapshot_file.exists() == file_written
         if file_written:
             assert snapshot_file_object._snapshot_statuses == expected_statuses
+
+    @staticmethod
+    def test_write_error(config: Config, metadata: SnapshotMetadata, snapshot_file: Path):
+        """ Test if an error occurs during snapshot writing, no file is written. """
+        # Arrange
+        snapshot_file_object = _SnapshotFile(config, metadata)
+        snapshot_file_object._changed_flag = True
+        snapshot_file_object.record_snapshot({("tuple as key",): None})
+
+        # Act
+        try:
+            snapshot_file_object.write()
+        except TypeError:
+            pass
+
+        # Assert
+        assert not snapshot_file.exists()
+        assert not list(snapshot_file.parent.glob("*"))


### PR DESCRIPTION
This fixes a bug where if a snapshot file is being written and an
error occurs during serialization, the file is left half written
and therefore unparsable.

The fix writes to a temporary file and moves to the snapshot file
location if no errors occurred, otherwise deleting the temporary
file.

Closes #43 