### PR TITLE
Decimal class serializer

### DIFF
--- a/snappiershot/serializers/constants.py
+++ b/snappiershot/serializers/constants.py
@@ -1,6 +1,7 @@
 """ Constant values used by the serializers. """
 import datetime
 from abc import ABC
+from decimal import Decimal
 from typing import Any, Dict, Iterator, List, NamedTuple, Set, Union
 
 _Primitive = Union[bool, float, int, None, str]
@@ -86,6 +87,9 @@ class CustomEncodedNumericTypes(_CustomEncodedTypeCollection):
 
     complex = _CustomEncodedType(
         type_=complex, name="complex", type_key=type_key, value_key=value_key
+    )
+    decimal = _CustomEncodedType(
+        type_=Decimal, name="decimal", type_key=type_key, value_key=value_key
     )
 
 

--- a/snappiershot/serializers/constants.py
+++ b/snappiershot/serializers/constants.py
@@ -2,10 +2,10 @@
 import datetime
 from abc import ABC
 from decimal import Decimal
-from typing import Any, Dict, Iterator, List, NamedTuple, Set, Tuple, Union
+from typing import Any, Dict, Iterator, List, NamedTuple, Set, Union
 
 _Primitive = Union[bool, float, int, None, str]
-JsonType = Union[_Primitive, Dict[str, Any], List[Any], Tuple[Any, ...]]
+JsonType = Union[_Primitive, Dict[str, Any], List[Any]]
 
 
 # noinspection PyUnresolvedReferences

--- a/snappiershot/serializers/constants.py
+++ b/snappiershot/serializers/constants.py
@@ -2,10 +2,10 @@
 import datetime
 from abc import ABC
 from decimal import Decimal
-from typing import Any, Dict, Iterator, List, NamedTuple, Set, Union
+from typing import Any, Dict, Iterator, List, NamedTuple, Set, Tuple, Union
 
 _Primitive = Union[bool, float, int, None, str]
-JsonType = Union[_Primitive, Dict[str, Any], List[Any]]
+JsonType = Union[_Primitive, Dict[str, Any], List[Any], Tuple[Any, ...]]
 
 
 # noinspection PyUnresolvedReferences

--- a/snappiershot/serializers/json.py
+++ b/snappiershot/serializers/json.py
@@ -106,7 +106,7 @@ class JsonSerializer(json.JSONEncoder):
             encoded_value: List[float] = [value.real, value.imag]
             return CustomEncodedNumericTypes.complex.json_encoding(encoded_value)
         if isinstance(value, Decimal):
-            encode_value: List[Any] = list(value.as_tuple())
+            encode_value: Dict[str, Any] = value.as_tuple()._asdict()
             return CustomEncodedNumericTypes.decimal.json_encoding(encode_value)
         raise NotImplementedError(
             f"No encoding implemented for the following numeric type: {value} ({type(value)})"
@@ -269,7 +269,7 @@ class JsonDeserializer(json.JSONDecoder):
             real, imag = value
             return complex(real, imag)
         if type_name == CustomEncodedNumericTypes.decimal.name:
-            return Decimal(DecimalTuple(value[0], value[1], value[2]))
+            return Decimal(DecimalTuple(**value))
 
         raise NotImplementedError(
             f"Deserialization for the following numerical type not implemented: {dct}"

--- a/tests/test_serializers/test_json.py
+++ b/tests/test_serializers/test_json.py
@@ -18,7 +18,18 @@ class TestNumericEncoding:
 
     NUMERIC_DECODING_TEST_CASES = [
         (3 + 4j, CustomEncodedNumericTypes.complex.json_encoding([3, 4])),
-        (Decimal(3.1415), CustomEncodedNumericTypes.decimal.json_encoding(3.1415)),
+        (
+            Decimal(3.1415),
+            CustomEncodedNumericTypes.decimal.json_encoding(
+                list(Decimal(3.1415).as_tuple())
+            ),
+        ),
+        (
+            Decimal("3.1415"),
+            CustomEncodedNumericTypes.decimal.json_encoding(
+                list(Decimal("3.1415").as_tuple())
+            ),
+        ),
     ]
 
     NUMERIC_ENCODING_TEST_CASES = [
@@ -204,7 +215,8 @@ def test_round_trip():
         "none": None,
         "int": 12,
         "float": 3.14,
-        "decimal": Decimal(3.1415),
+        "decimal_1": Decimal(3.1415),
+        "decimal_2": Decimal("3.1415"),
         "inf": inf,
         "complex": 3 + 4j,
         "string": "string",

--- a/tests/test_serializers/test_json.py
+++ b/tests/test_serializers/test_json.py
@@ -18,6 +18,7 @@ class TestNumericEncoding:
 
     NUMERIC_DECODING_TEST_CASES = [
         (3 + 4j, CustomEncodedNumericTypes.complex.json_encoding([3, 4])),
+        (Decimal(3.1415), CustomEncodedNumericTypes.decimal.json_encoding(3.1415)),
     ]
 
     NUMERIC_ENCODING_TEST_CASES = [
@@ -43,7 +44,7 @@ class TestNumericEncoding:
     def test_encode_numeric_error():
         """ Test that the JsonSerializer.encode_numeric raises an error if no encoding is defined. """
         # Arrange
-        value = Decimal("3.14")
+        value = "3.121"
 
         # Act & Assert
         with pytest.raises(NotImplementedError):
@@ -203,6 +204,7 @@ def test_round_trip():
         "none": None,
         "int": 12,
         "float": 3.14,
+        "decimal": Decimal(3.1415),
         "inf": inf,
         "complex": 3 + 4j,
         "string": "string",

--- a/tests/test_serializers/test_json.py
+++ b/tests/test_serializers/test_json.py
@@ -21,13 +21,13 @@ class TestNumericEncoding:
         (
             Decimal(3.1415),
             CustomEncodedNumericTypes.decimal.json_encoding(
-                list(Decimal(3.1415).as_tuple())
+                Decimal(3.1415).as_tuple()._asdict()
             ),
         ),
         (
             Decimal("3.1415"),
             CustomEncodedNumericTypes.decimal.json_encoding(
-                list(Decimal("3.1415").as_tuple())
+                Decimal("3.1415").as_tuple()._asdict()
             ),
         ),
     ]


### PR DESCRIPTION
**Describe the Changes**
Implemented Decimal class serialization / deserialization.

**Example Code**

```python
import decimal

data = decimal.Decimal(3.14)

serialized = json.dumps(data, cls=JsonSerializer)
# serialized = {'__snappiershot_numeric__': 'decimal', 'value': 3.14}

deserialized = json.loads(serialized, cls=JsonDeserializer)
# deserialized = decimal.Decimal(3.14)

assert deserialized == data
```

**Additional Notes**
Implemented as a custom numeric type.

