### PR TITLE
Bytes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ You can open an issue [here](https://github.com/MORSECorp/snappiershot/issues/ne
 
 
 ## Environment Setup
-We use the [poetry](https://python-poetry.org/) to both manage dependencies
+We use [poetry](https://python-poetry.org/) to both manage dependencies
   and publish this package. You can find information about installing this
   software [here](https://python-poetry.org/docs/).
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ $ pip install snappiershot
 ```
 
 ## Configuration
-Snappiershot is following the [trend of packages](https://github.com/carlosperate/awesome-pyproject/)
+SnappierShot is following the [trend of packages](https://github.com/carlosperate/awesome-pyproject/)
 in performing project-wide configuration through the pyproject.toml file established by
 [PEP 518](https://www.python.org/dev/peps/pep-0518/).
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ $ pip install snappiershot
 ```
 
 ## Configuration
-Snappier shot is following the [trend of packages](https://github.com/carlosperate/awesome-pyproject/)
+Snappiershot is following the [trend of packages](https://github.com/carlosperate/awesome-pyproject/)
 in performing project-wide configuration through the pyproject.toml file established by
 [PEP 518](https://www.python.org/dev/peps/pep-0518/).
 
-Within the pyproject.toml file, all snappiershot configuration can be found under the
+Within the pyproject.toml file, all SnappierShot configuration can be found under the
 `[tool.snappiershot]` heading.
 
 ### Example (with default values):

--- a/snappiershot/serializers/constants.py
+++ b/snappiershot/serializers/constants.py
@@ -146,6 +146,9 @@ class CustomEncodedCollectionTypes(_CustomEncodedTypeCollection):
     tuple = _CustomEncodedType(
         type_=tuple, name="tuple", type_key=type_key, value_key=value_key
     )
+    bytes = _CustomEncodedType(
+        type_=bytes, name="bytes", type_key=type_key, value_key=value_key
+    )
 
 
 # Tuples of types intended to be used for isinstance checking.

--- a/snappiershot/serializers/json.py
+++ b/snappiershot/serializers/json.py
@@ -207,6 +207,8 @@ class JsonSerializer(json.JSONEncoder):
             return CustomEncodedCollectionTypes.set.json_encoding(list(value))
         if isinstance(value, tuple):
             return CustomEncodedCollectionTypes.tuple.json_encoding(list(value))
+        if isinstance(value, bytes):
+            return CustomEncodedCollectionTypes.bytes.json_encoding(list(value))
         raise NotImplementedError(
             f"No encoding implemented for the following collection type: {value} ({type(value)})"
         )
@@ -356,6 +358,9 @@ class JsonDeserializer(json.JSONDecoder):
 
         if type_name == CustomEncodedCollectionTypes.tuple.name:
             return tuple(values)
+
+        if type_name == CustomEncodedCollectionTypes.bytes.name:
+            return bytes(values)
 
         raise NotImplementedError(
             f"Deserialization for the following collection type not implemented: {dct}"

--- a/tests/test_serializers/test_json.py
+++ b/tests/test_serializers/test_json.py
@@ -155,6 +155,7 @@ class TestCollectionEncoding:
     COLLECTION_DECODING_TEST_CASES = [
         ({1, 2, 3}, CustomEncodedCollectionTypes.set.json_encoding([1, 2, 3])),
         ((1, 2, 3), CustomEncodedCollectionTypes.tuple.json_encoding([1, 2, 3])),
+        (b"\x01\x02\x03", CustomEncodedCollectionTypes.bytes.json_encoding([1, 2, 3]),),
     ]
 
     COLLECTION_ENCODING_TEST_CASES = [
@@ -166,7 +167,7 @@ class TestCollectionEncoding:
     def test_encode_collection_error():
         """ Test that the JsonSerializer.encode_collection raises an error if no encoding is defined. """
         # Arrange
-        value = b"banana"
+        value = bytearray(10)
 
         # Act & Assert
         with pytest.raises(NotImplementedError):
@@ -235,6 +236,7 @@ def test_round_trip():
         "complex_list": [1, 2, (3, 4, {5})],
         "my_test": {(1, 2), (3, 4)},
         "my_test2": {"one", "two"},
+        "bytes": b"bytes",
     }
 
     # Act


### PR DESCRIPTION
**Describe the Changes**
This PR adds support for encoding `bytes` type collections to the custom collection encoder.

**Example Code**
This change does not affect the public API except by removing the NotImplementedException for `bytes` objects.

**Additional Notes**
Included minor corrections to typos in the documentation.

**Future Work**
N/A