### PR TITLE
Numpy

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1,41 +1,40 @@
 [[package]]
-category = "dev"
-description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 name = "appdirs"
+version = "1.4.4"
+description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+category = "dev"
 optional = false
 python-versions = "*"
-version = "1.4.4"
 
 [[package]]
-category = "dev"
-description = "Atomic file writes."
-marker = "sys_platform == \"win32\""
 name = "atomicwrites"
+version = "1.4.0"
+description = "Atomic file writes."
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.4.0"
 
 [[package]]
-category = "dev"
-description = "Classes Without Boilerplate"
 name = "attrs"
+version = "20.3.0"
+description = "Classes Without Boilerplate"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "20.3.0"
 
 [package.extras]
-dev = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "furo", "sphinx", "pre-commit"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "furo", "sphinx", "pre-commit"]
 docs = ["furo", "sphinx", "zope.interface"]
-tests = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
-tests_no_zope = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
 
 [[package]]
-category = "dev"
-description = "The uncompromising code formatter."
 name = "black"
+version = "19.10b0"
+description = "The uncompromising code formatter."
+category = "dev"
 optional = false
 python-versions = ">=3.6"
-version = "19.10b0"
 
 [package.dependencies]
 appdirs = "*"
@@ -50,93 +49,88 @@ typed-ast = ">=1.4.0"
 d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
 
 [[package]]
-category = "dev"
-description = "Validate configuration and produce human readable error messages."
 name = "cfgv"
+version = "3.2.0"
+description = "Validate configuration and produce human readable error messages."
+category = "dev"
 optional = false
 python-versions = ">=3.6.1"
-version = "3.2.0"
 
 [[package]]
-category = "dev"
-description = "Composable command line interface toolkit"
 name = "click"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 version = "7.1.2"
-
-[[package]]
+description = "Composable command line interface toolkit"
 category = "dev"
-description = "Cross-platform colored terminal text."
-marker = "sys_platform == \"win32\""
-name = "colorama"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "0.4.4"
 
 [[package]]
+name = "colorama"
+version = "0.4.4"
+description = "Cross-platform colored terminal text."
 category = "dev"
-description = "Code coverage measurement for Python"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
 name = "coverage"
+version = "5.3"
+description = "Code coverage measurement for Python"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
-version = "5.3"
 
 [package.extras]
 toml = ["toml"]
 
 [[package]]
-category = "dev"
-description = "Distribution utilities"
 name = "distlib"
-optional = false
-python-versions = "*"
 version = "0.3.1"
-
-[[package]]
+description = "Distribution utilities"
 category = "dev"
-description = "A platform independent file lock."
-name = "filelock"
 optional = false
 python-versions = "*"
-version = "3.0.12"
 
 [[package]]
+name = "filelock"
+version = "3.0.12"
+description = "A platform independent file lock."
 category = "dev"
-description = "the modular source code checker: pep8 pyflakes and co"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "flake8"
+version = "3.8.4"
+description = "the modular source code checker: pep8 pyflakes and co"
+category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "3.8.4"
 
 [package.dependencies]
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 mccabe = ">=0.6.0,<0.7.0"
 pycodestyle = ">=2.6.0a1,<2.7.0"
 pyflakes = ">=2.2.0,<2.3.0"
 
-[package.dependencies.importlib-metadata]
-python = "<3.8"
-version = "*"
-
 [[package]]
-category = "dev"
-description = "File identification library for Python"
 name = "identify"
+version = "1.5.10"
+description = "File identification library for Python"
+category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "1.5.10"
 
 [package.extras]
 license = ["editdistance"]
 
 [[package]]
-category = "main"
-description = "Read metadata from Python packages"
-marker = "python_version < \"3.8\""
 name = "importlib-metadata"
+version = "3.1.0"
+description = "Read metadata from Python packages"
+category = "main"
 optional = false
 python-versions = ">=3.6"
-version = "3.1.0"
 
 [package.dependencies]
 zipp = ">=0.5"
@@ -146,45 +140,42 @@ docs = ["sphinx", "rst.linker"]
 testing = ["packaging", "pep517", "unittest2", "importlib-resources (>=1.3)"]
 
 [[package]]
-category = "dev"
-description = "Read resources from Python packages"
-marker = "python_version < \"3.7\""
 name = "importlib-resources"
+version = "3.3.0"
+description = "Read resources from Python packages"
+category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
-version = "3.3.0"
 
 [package.dependencies]
-[package.dependencies.zipp]
-python = "<3.8"
-version = ">=0.4"
+zipp = {version = ">=0.4", markers = "python_version < \"3.8\""}
 
 [package.extras]
 docs = ["sphinx", "rst.linker", "jaraco.packaging"]
 
 [[package]]
-category = "dev"
-description = "iniconfig: brain-dead simple config-ini parsing"
 name = "iniconfig"
-optional = false
-python-versions = "*"
 version = "1.1.1"
-
-[[package]]
+description = "iniconfig: brain-dead simple config-ini parsing"
 category = "dev"
-description = "McCabe checker, plugin for flake8"
-name = "mccabe"
 optional = false
 python-versions = "*"
-version = "0.6.1"
 
 [[package]]
+name = "mccabe"
+version = "0.6.1"
+description = "McCabe checker, plugin for flake8"
 category = "dev"
-description = "Optional static typing for Python"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "mypy"
+version = "0.782"
+description = "Optional static typing for Python"
+category = "dev"
 optional = false
 python-versions = ">=3.5"
-version = "0.782"
 
 [package.dependencies]
 mypy-extensions = ">=0.4.3,<0.5.0"
@@ -195,48 +186,48 @@ typing-extensions = ">=3.7.4"
 dmypy = ["psutil (>=4.0)"]
 
 [[package]]
-category = "dev"
-description = "Experimental type system extensions for programs checked with the mypy typechecker."
 name = "mypy-extensions"
-optional = false
-python-versions = "*"
 version = "0.4.3"
-
-[[package]]
+description = "Experimental type system extensions for programs checked with the mypy typechecker."
 category = "dev"
-description = "Node.js virtual environment builder"
-name = "nodeenv"
 optional = false
 python-versions = "*"
-version = "1.5.0"
 
 [[package]]
-category = "main"
-description = "NumPy is the fundamental package for array computing with Python."
+name = "nodeenv"
+version = "1.5.0"
+description = "Node.js virtual environment builder"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "numpy"
+version = "1.19.4"
+description = "NumPy is the fundamental package for array computing with Python."
+category = "main"
 optional = false
 python-versions = ">=3.6"
-version = "1.19.4"
 
 [[package]]
-category = "dev"
-description = "Core utilities for Python packages"
 name = "packaging"
+version = "20.4"
+description = "Core utilities for Python packages"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "20.4"
 
 [package.dependencies]
 pyparsing = ">=2.0.2"
 six = "*"
 
 [[package]]
-category = "main"
-description = "Powerful data structures for data analysis, time series, and statistics"
 name = "pandas"
+version = "1.1.4"
+description = "Powerful data structures for data analysis, time series, and statistics"
+category = "main"
 optional = false
 python-versions = ">=3.6.1"
-version = "1.1.4"
 
 [package.dependencies]
 numpy = ">=1.15.4"
@@ -247,126 +238,115 @@ pytz = ">=2017.2"
 test = ["pytest (>=4.0.2)", "pytest-xdist", "hypothesis (>=3.58)"]
 
 [[package]]
-category = "dev"
-description = "Utility library for gitignore style pattern matching of file paths."
 name = "pathspec"
+version = "0.8.1"
+description = "Utility library for gitignore style pattern matching of file paths."
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "0.8.1"
 
 [[package]]
-category = "dev"
-description = "plugin and hook calling mechanisms for python"
 name = "pluggy"
+version = "0.13.1"
+description = "plugin and hook calling mechanisms for python"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "0.13.1"
 
 [package.dependencies]
-[package.dependencies.importlib-metadata]
-python = "<3.8"
-version = ">=0.12"
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
 dev = ["pre-commit", "tox"]
 
 [[package]]
-category = "main"
-description = "The standard library pprint module, but sets are always ordered."
 name = "pprint-ordered-sets"
+version = "1.0.0"
+description = "The standard library pprint module, but sets are always ordered."
+category = "main"
 optional = false
 python-versions = ">=3.6.1,<4.0.0"
-version = "1.0.0"
 
 [[package]]
-category = "dev"
-description = "A framework for managing and maintaining multi-language pre-commit hooks."
 name = "pre-commit"
+version = "2.9.0"
+description = "A framework for managing and maintaining multi-language pre-commit hooks."
+category = "dev"
 optional = false
 python-versions = ">=3.6.1"
-version = "2.9.0"
 
 [package.dependencies]
 cfgv = ">=2.0.0"
 identify = ">=1.0.0"
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+importlib-resources = {version = "*", markers = "python_version < \"3.7\""}
 nodeenv = ">=0.11.1"
 pyyaml = ">=5.1"
 toml = "*"
 virtualenv = ">=20.0.8"
 
-[package.dependencies.importlib-metadata]
-python = "<3.8"
-version = "*"
-
-[package.dependencies.importlib-resources]
-python = "<3.7"
-version = "*"
-
 [[package]]
-category = "dev"
-description = "library with cross-python path, ini-parsing, io, code, log facilities"
 name = "py"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "1.9.0"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
-category = "dev"
-description = "Python style guide checker"
 name = "pycodestyle"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "2.6.0"
-
-[[package]]
+description = "Python style guide checker"
 category = "dev"
-description = "passive checker of Python programs"
-name = "pyflakes"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.2.0"
 
 [[package]]
+name = "pyflakes"
+version = "2.2.0"
+description = "passive checker of Python programs"
 category = "dev"
-description = "Python parsing module"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
 name = "pyparsing"
+version = "2.4.7"
+description = "Python parsing module"
+category = "dev"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "2.4.7"
 
 [[package]]
-category = "dev"
-description = "pytest: simple powerful testing with Python"
 name = "pytest"
+version = "6.1.2"
+description = "pytest: simple powerful testing with Python"
+category = "dev"
 optional = false
 python-versions = ">=3.5"
-version = "6.1.2"
 
 [package.dependencies]
-atomicwrites = ">=1.0"
+atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
 attrs = ">=17.4.0"
-colorama = "*"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<1.0"
 py = ">=1.8.2"
 toml = "*"
 
-[package.dependencies.importlib-metadata]
-python = "<3.8"
-version = ">=0.12"
-
 [package.extras]
-checkqa_mypy = ["mypy (0.780)"]
+checkqa_mypy = ["mypy (==0.780)"]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
-category = "dev"
-description = "Thin-wrapper around the mock package for easier use with pytest"
 name = "pytest-mock"
+version = "3.3.1"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+category = "dev"
 optional = false
 python-versions = ">=3.5"
-version = "3.3.1"
 
 [package.dependencies]
 pytest = ">=5.0"
@@ -375,125 +355,119 @@ pytest = ">=5.0"
 dev = ["pre-commit", "tox", "pytest-asyncio"]
 
 [[package]]
-category = "main"
-description = "Extensions to the standard Python datetime module"
 name = "python-dateutil"
+version = "2.8.1"
+description = "Extensions to the standard Python datetime module"
+category = "main"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
-version = "2.8.1"
 
 [package.dependencies]
 six = ">=1.5"
 
 [[package]]
-category = "main"
-description = "World timezone definitions, modern and historical"
 name = "pytz"
+version = "2020.4"
+description = "World timezone definitions, modern and historical"
+category = "main"
 optional = false
 python-versions = "*"
-version = "2020.4"
 
 [[package]]
-category = "dev"
-description = "YAML parser and emitter for Python"
 name = "pyyaml"
+version = "5.3.1"
+description = "YAML parser and emitter for Python"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "5.3.1"
 
 [[package]]
-category = "dev"
-description = "Alternative regular expression module, to replace re."
 name = "regex"
+version = "2020.11.13"
+description = "Alternative regular expression module, to replace re."
+category = "dev"
 optional = false
 python-versions = "*"
-version = "2020.11.13"
 
 [[package]]
-category = "main"
-description = "Python 2 and 3 compatibility utilities"
 name = "six"
+version = "1.15.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "1.15.0"
 
 [[package]]
-category = "dev"
-description = "Python Library for Tom's Obvious, Minimal Language"
 name = "toml"
+version = "0.10.2"
+description = "Python Library for Tom's Obvious, Minimal Language"
+category = "dev"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "0.10.2"
 
 [[package]]
-category = "main"
-description = "Style preserving TOML library"
 name = "tomlkit"
+version = "0.7.0"
+description = "Style preserving TOML library"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "0.7.0"
 
 [[package]]
-category = "dev"
-description = "a fork of Python 2 and 3 ast modules with type comment support"
 name = "typed-ast"
-optional = false
-python-versions = "*"
 version = "1.4.1"
-
-[[package]]
+description = "a fork of Python 2 and 3 ast modules with type comment support"
 category = "dev"
-description = "Backported and Experimental Type Hints for Python 3.5+"
-name = "typing-extensions"
 optional = false
 python-versions = "*"
-version = "3.7.4.3"
 
 [[package]]
+name = "typing-extensions"
+version = "3.7.4.3"
+description = "Backported and Experimental Type Hints for Python 3.5+"
 category = "dev"
-description = "Virtual Python Environment builder"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "virtualenv"
+version = "20.2.1"
+description = "Virtual Python Environment builder"
+category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "20.2.1"
 
 [package.dependencies]
 appdirs = ">=1.4.3,<2"
 distlib = ">=0.3.1,<1"
 filelock = ">=3.0.0,<4"
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+importlib-resources = {version = ">=1.0", markers = "python_version < \"3.7\""}
 six = ">=1.9.0,<2"
-
-[package.dependencies.importlib-metadata]
-python = "<3.8"
-version = ">=0.12"
-
-[package.dependencies.importlib-resources]
-python = "<3.7"
-version = ">=1.0"
 
 [package.extras]
 docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=19.9.0rc1)"]
 testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)", "pytest-xdist (>=1.31.0)", "packaging (>=20.0)", "xonsh (>=0.9.16)"]
 
 [[package]]
-category = "main"
-description = "Backport of pathlib-compatible object wrapper for zip files"
-marker = "python_version < \"3.8\""
 name = "zipp"
+version = "3.4.0"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+category = "main"
 optional = false
 python-versions = ">=3.6"
-version = "3.4.0"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
+testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [extras]
 pandas = ["pandas"]
 
 [metadata]
-content-hash = "2aa967983ae8fd551c5509e441172445889fa9976931130775b51dca970178fc"
+lock-version = "1.1"
 python-versions = "^3.6.1"
+content-hash = "8f08f97205e005de4076c871e2a7c9cb61ad6d0733b3756cc831c86715a5e6f5"
 
 [metadata.files]
 appdirs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ pandas = ">=0.20.0"
 pre-commit = "^2.6.0"
 pytest = "^6.0.1"
 pytest_mock = "^3.3.1"
+numpy = "^1.19.4"
 
 [tool.poetry.plugins.pytest11]
 snappiershot = "snappiershot.plugins.pytest"

--- a/snappiershot/serializers/optional_module_utils.py
+++ b/snappiershot/serializers/optional_module_utils.py
@@ -1,6 +1,6 @@
 """ Utilities for handling optional modules """
 from types import ModuleType
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 EncodedPandasType = Dict[str, List[Any]]
 
@@ -65,4 +65,119 @@ class Pandas:
 
         raise NotImplementedError(
             f"No encoding implemented for the following pandas type: {value} ({type(value)})"
+        )
+
+
+class Numpy:
+
+    _primative_names = (
+        "bool_",
+        "byte",
+        "ubyte",
+        "short",
+        "ushort",
+        "intc",
+        "uintc",
+        "int_",
+        "uint",
+        "longlong",
+        "ulonglong",
+        "float16",
+        "single",
+        "double",
+        "longdouble",
+        "csingle",
+        "cdouble",
+        "clongdouble",
+        "int8",
+        "int16",
+        "int32",
+        "int64",
+        "uint8",
+        "uint16",
+        "uint32",
+        "uint64",
+        "intp",
+        "uintp",
+        "float32",
+        "float64",
+        "complex64",
+        "complex128",
+        "complex_",
+    )
+
+    @staticmethod
+    def is_numpy_object(obj: Any) -> bool:
+        """Return true if the given object is a numpy array
+
+        A special effort is made to avoid importing numpy unless it's really necessary.
+        As such, this is checked by looking for "numpy" in the __module__ attribute
+        of the object's type
+
+        """
+        return "numpy" in getattr(type(obj), "__module__", "").split(".")
+
+    @staticmethod
+    def get_numpy(
+        raise_error: bool = False, custom_error_message: str = ""
+    ) -> Optional[ModuleType]:
+        """ Return numpy module, if it is already imported, otherwise return None
+
+        Args:
+            raise_error: if True, e.g. when numpy is required, raise an error
+            custom_error_message: string, custom error message to use in place of default error message
+
+        Returns:
+            numpy module, or None if not found
+
+        Raises:
+            Import error if numpy is not found and import is required
+        """
+        try:
+            import numpy as np
+        except ImportError as error:
+            np = None
+            if raise_error:
+                default_error_message = "numpy is required for snappiershot testing when snapshotting numpy arrays"
+                raise ImportError(custom_error_message or default_error_message) from error
+        return np
+
+    @classmethod
+    def _get_numpy_primatives(cls, np: ModuleType) -> Tuple[type]:
+        """ Get numpy primative types
+        Based on https://numpy.org/devdocs/user/basics.types.html
+
+        Args:
+            np: numpy module
+
+        Returns:
+            Tuple of numpy primative types
+        """
+        primative_types = tuple(
+            [
+                getattr(np, name, None)
+                for name in cls._primative_names
+                if getattr(np, name, None) is not None
+            ]
+        )
+        return primative_types  # type: ignore
+
+    @classmethod
+    def encode_numpy(cls, value: Any) -> Any:
+        """ Encoding given numpy object
+
+        Raises:
+            NotImplementedError - If encoding is not implemented for the given numpy type.
+        """
+        # A special effort is made to avoid importing numpy unless it's really necessary.
+        np = cls.get_numpy(raise_error=True)
+
+        if isinstance(value, np.ndarray):  # type: ignore
+            return value.tolist()
+
+        if isinstance(value, cls._get_numpy_primatives(np)):
+            return value.item()  # type: ignore
+
+        raise NotImplementedError(
+            f"No encoding implemented for the following numpy type: {value} ({type(value)})"
         )

--- a/snappiershot/serializers/utils.py
+++ b/snappiershot/serializers/utils.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Sequence
 from ..constants import ENCODING_FUNCTION_NAME, SNAPSHOT_DIRECTORY
 from ..errors import SnappierShotWarning
 from .constants import SERIALIZABLE_TYPES, JsonType
-from .optional_module_utils import Pandas
+from .optional_module_utils import Numpy, Pandas
 
 
 def default_encode_value(value: Any) -> JsonType:
@@ -52,6 +52,11 @@ def default_encode_value(value: Any) -> JsonType:
     if Pandas.is_pandas_object(value):
         encoded_pandas = Pandas.encode_pandas(value)
         return default_encode_value(encoded_pandas)
+
+    # If the value is a numpy object, encode and recurse
+    if Numpy.is_numpy_object(value):
+        encoded_numpy = Numpy.encode_numpy(value)
+        return default_encode_value(encoded_numpy)
 
     # If the value is an instanced class.
     if is_instanced_object(value):

--- a/tests/test_serializers/test_optional_module_utils.py
+++ b/tests/test_serializers/test_optional_module_utils.py
@@ -1,8 +1,9 @@
 """ Tests for snappiershot/serializers/optional_module_utils.py """
+import numpy as np
 import pandas as pd
 import pytest
 from pytest_mock import MockFixture
-from snappiershot.serializers.optional_module_utils import Pandas
+from snappiershot.serializers.optional_module_utils import Numpy, Pandas
 
 
 class TestPandas:
@@ -94,3 +95,143 @@ class TestPandas:
         # Act & Assert
         with pytest.raises(NotImplementedError):
             Pandas.encode_pandas(value)
+
+
+class TestNumpy:
+    @staticmethod
+    def test_get_numpy() -> None:
+        """
+        Test get_numpy when module is present
+        """
+        # Arrange
+
+        # Act
+        result = Numpy.get_numpy()
+
+        # Assert
+        assert result is np
+
+    @staticmethod
+    def test_get_numpy_missing(mocker: MockFixture) -> None:
+        """
+        Test get_numpy when module is missing
+        """
+        # Arrange
+        mocker.patch.dict("sys.modules", {"numpy": None})
+
+        # Act
+        result = Numpy.get_numpy()
+
+        # Assert
+        assert result is None
+
+    @staticmethod
+    def test_get_numpy_missing_error(mocker: MockFixture) -> None:
+        """
+        Test get_numpy when module is missing raises error
+        """
+        # Arrange
+        mocker.patch.dict("sys.modules", {"numpy": None})
+
+        # Act / assert
+        with pytest.raises(ImportError, match="foo"):
+            Numpy.get_numpy(raise_error=True, custom_error_message="foo")
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "value, expected", [(np.array([1, 2, 3]), True), ([1, 2, 3], False)]
+    )
+    def test_is_numpy_object(value, expected) -> None:
+        """
+        Test is_numpy_object
+        """
+        # Arrange
+
+        # Act
+        result = Numpy.is_numpy_object(value)
+
+        # Assert
+        assert result == expected
+
+    @staticmethod
+    def test_get_numpy_primatives() -> None:
+        """
+        Test _get_numpy_primatives
+        """
+        # Arrange
+
+        # Act
+        result = Numpy._get_numpy_primatives(np)
+
+        # Assert
+        assert len(result) == 33  # Expected number of types
+        for thing in result:
+            assert "numpy" in getattr(thing, "__module__", "").split(
+                "."
+            )  # Check that type is from numpy
+            assert type(thing) is type  # Check that each type is a type
+
+    @staticmethod
+    def test_encode_numpy_error():
+        """ Test that the encode_numpy raises an error if no encoding is defined. """
+        # Arrange
+        value = "not a numpy"
+
+        # Act & Assert
+        with pytest.raises(NotImplementedError):
+            Numpy.encode_numpy(value)
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            # fmt: off
+            (np.array([['balloons'], ['are'], ['awesome']]),
+             [['balloons'], ['are'], ['awesome']]),
+            (np.bool_(1), True),
+            (np.byte(4), 4),
+            (np.ubyte(4), 4),
+            (np.short(4), 4),
+            (np.ushort(4), 4),
+            (np.intc(4), 4),
+            (np.uintc(4), 4),
+            (np.int_(4), 4),
+            (np.uint(4), 4),
+            (np.longlong(4), 4),
+            (np.ulonglong(4), 4),
+            (np.float16(4), 4),
+            (np.single(4), 4),
+            (np.double(4), 4),
+            (np.longdouble(4), 4),
+            (np.csingle(4), 4),
+            (np.cdouble(4), 4),
+            (np.clongdouble(4), 4),
+            (np.int8(4), 4),
+            (np.int16(4), 4),
+            (np.int32(4), 4),
+            (np.int64(4), 4),
+            (np.uint8(4), 4),
+            (np.uint16(4), 4),
+            (np.uint32(4), 4),
+            (np.uint64(4), 4),
+            (np.intp(4), 4),
+            (np.uintp(4), 4),
+            (np.float32(4), 4),
+            (np.float64(4), 4),
+            (np.complex64(4), 4 + 0j),
+            (np.complex128(4), 4 + 0j),
+            (np.complex_(4), 4 + 0j),
+            # fmt: on
+        ],
+    )
+    def test_encode_numpy(value, expected) -> None:
+        """
+        Test encode_numpy
+        """
+        # Arrange
+
+        # Act
+        result = Numpy.encode_numpy(value)
+
+        # Assert
+        assert result == expected

--- a/tests/test_serializers/test_utils.py
+++ b/tests/test_serializers/test_utils.py
@@ -1,6 +1,7 @@
 """ Tests for snappiershot/serializers/utils.py """
 from types import SimpleNamespace
 
+import numpy as np
 import pandas as pd
 import pytest
 from snappiershot.serializers.utils import (
@@ -145,6 +146,28 @@ class TestDefaultEncodeValue:
     def test_encode_pandas_recurse(value, expected) -> None:
         """
         Test recursive encoding of pandas objects
+        """
+        # Arrange
+
+        # Act
+        result = default_encode_value(value)
+
+        # Assert
+        assert result == expected
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            # fmt: off
+            (np.array(['balloons', 'are', 'awesome']), ['balloons', 'are', 'awesome']),
+            ([np.float16(4), np.uint(4)], [4, 4]),
+            # fmt: on
+        ],
+    )
+    def test_encode_numpy_recurse(value, expected) -> None:
+        """
+        Test recursive encoding of numpy objects
         """
         # Arrange
 


### PR DESCRIPTION
**Describe the Changes**
Add support for default-encoding numpy arrays and primatives. Adds numpy as a strictly optional module

**Example Code**
If you have added to the public API, please provide a code sample of how
  to use these additions.
```python
import numpy as np
import snappiershot

data = np.array([['balloons'], ['are'], ['awesome']])
result = snappiershot.serializers.utils.default_encode_value(data)
print(result)
# Prints: 
# [['balloons'], ['are'], ['awesome']]
```

**Additional Notes**
This adds numpy encoding to the default encoding (not the JSON serialization)

**Future Work**
n/a

Closes #25 