### PR TITLE
Fix custom object comparisons, allow for custom uninstantiated class encoding, fix float comparisons, allow for ignoring metadata

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 19.10b0
+    rev: 22.3.0
     hooks:
       - id: black
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ We use [poetry](https://python-poetry.org/) to both manage dependencies
   and publish this package. You can find information about installing this
   software [here](https://python-poetry.org/docs/).
 
-This library supports Python versions `3.6.1` and above, so you must have
+This library supports Python versions `3.6.2` and above, so you must have
   a version of Python installed that meets those specifications in order to
   progress any further with setting up your environment. We use the
   excellent [pyenv](https://github.com/pyenv/pyenv) to manage our local

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ SnappierShot uses metadata to find tests stored in each snapshot file. Metadata 
 * Do not run `assert_match` within a loop
 * Do not try to snapshot uninstantiated classes/objects or use them as inputs to a test method
 * If an unsupported object type cannot be snapshotted, see [CONTRIBUTING.md](CONTRIBUTING.md) for instructions on how to contribute to the project
-  * `__snapshot__` and `__snapshotskip__` are temporary workarounds that can be added to a custom object class to define user specific encoding instructions, but this feature is hacky and not robust yet
+  * `__snapshot__` and `__metadata_override__` are temporary workarounds that can be added to a custom object class to define user specific encoding instructions, but this feature is hacky and not robust yet
 
 
 ### Pytest Examples
@@ -103,7 +103,7 @@ Warning: Use these methods is hacky and should not be relied on.
 
 
 * `__snapshot__` overrides serializing behavior for instanced custom objects
-* `__snapshotskip__` overrides serializing behavior for uninstanced custom objects
+* `__metadata_override__` overrides serializing behavior for uninstanced custom objects
 
 ```python
 from snappiershot import Snapshot as Snappy
@@ -122,7 +122,7 @@ class CustomClass:
     return encoding
 
   @classmethod
-  def __snapshotskip__(cls):
+  def __metadata_override__(cls):
     return "test string"
 
 
@@ -174,7 +174,7 @@ def test_fallible_function(snapshot):
   * Dictionaries
   * Classes (with an underlying `__dict__`, `__slots__`, or `to_dict()`)
   * Unit types from the `pint` package
-  * Classes with custom encoding (by defining a `__snapshot__` or `__snapshotskip__` method)
+  * Classes with custom encoding (by defining a `__snapshot__` or `__metadata_override__` method)
 
 ## Contributing
 See [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ SnappierShot uses metadata to find tests stored in each snapshot file. Metadata 
 * Do not try to snapshot uninstantiated classes/objects or use them as inputs to a test method
 * If an unsupported object type cannot be recorded, see [CONTRIBUTING.md](CONTRIBUTING.md) for instructions on how
   to contribute to the project
-  * `__snapshot__` and `__metadata_override__` are temporary workarounds described below
+  * `__snapshot__` is a workaround described below
 
 
 ### Pytest Examples
@@ -100,17 +100,13 @@ def test_no_pytest_runner():
 ```
 
 ### Custom Encoding and Override Examples
-Warning: Use these methods is hacky and should not be relied on.
+Warning: Use of this method is currently still a little hacky
 
-
-* `__snapshot__` overrides serializing behavior for objects being recorded
+* `__snapshot__` overrides serializing behavior for class objects being recorded
   * Useful for partially recording class objects with many unnecessary properties
-* `__metadata_override__` overrides serializing behavior for metadata being recorded
-  * Useful for recording type objects (uninstantiated classes) via bypassing the default
-    encoding process
 
 ```python
-from snappiershot import Snapshot as Snappy
+from snappiershot import Snapshot
 from pytest import fixture
 
 class CustomClass:
@@ -125,26 +121,16 @@ class CustomClass:
     }
     return encoding
 
-  @classmethod
-  def __metadata_override__(cls):
-    return "test string"
-
-
 @fixture
-def instanced_input() -> CustomClass:
-  instanced_input = CustomClass()
-  return instanced_input
+def class_input() -> CustomClass:
+  class_input = CustomClass()
+  return class_input
 
-@fixture
-def uninstanced_input() -> type(CustomClass):
-  instanced_input = CustomClass
-  return instanced_input
-
-def test_class(uninstanced_input: type(CustomClass), instanced_input: CustomClass, snapshot: Snappy):
-    """ Test encoding snapshot and metadata for a custom class both instanced and un-instanced """
+def test_class(class_input: CustomClass, snapshot: Snapshot):
+    """ Test encoding snapshot and metadata for a custom class """
 
     # Act
-    result = (instanced_input, uninstanced_input)
+    result = class_input
 
     # Assert
     snapshot.assert_match(result)
@@ -178,7 +164,7 @@ def test_fallible_function(snapshot):
   * Dictionaries
   * Classes (with an underlying `__dict__`, `__slots__`, or `to_dict`)
   * Unit types from the `pint` package
-  * Classes with custom encoding (by defining a `__snapshot__` or `__metadata_override__` method)
+  * Classes with custom encoding (by defining a `__snapshot__` method)
 
 ## Contributing
 See [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -51,12 +51,11 @@ SnappierShot uses metadata to find tests stored in each snapshot file. Metadata 
 
 
 ### Pytest Examples
-Implementing this way will not properly source the snappiershot reference
 ```python
-from snappiershot import Snapshot as Snappy
+from snappiershot import Snapshot
 
-def test_no_documentation(snapshot):
-    """ Will not attach proper SnappierShot documentation to assert_match """
+def test_basic(snapshot: Snapshot):
+    """ Will do a basic snapshotting of one value with no metadata """
     # Arrange
     x = 1
     y = 2
@@ -67,29 +66,18 @@ def test_no_documentation(snapshot):
     # Assert
     snapshot.assert_match(result)
 
-def test_documentation(snapshot: Snappy):
-    """ Will attach proper SnappierShot documentation to assert_match """
-    # Arrange
-    x = 1
-    y = 2
-
-    # Act
-    result = x + y
-
-    # Assert
-    snapshot.assert_match(result)
-
-def test_ignore_metadata(snapshot: Snappy, ignored_input: str = "ignore me"):
+def test_ignore_metadata(snapshot: Snapshot, input_to_ignore: str = "ignore me"):
     """ Test that metadata gets ignored """
     # Arrange
     x = 1
     y = 2
+    ignored_input = ["input_to_ignore"]
 
     # Act
     result = x + y
 
     # Assert
-    snapshot.assert_match(result, ignore=["ignored_input"])
+    snapshot.assert_match(result, ignore=ignored_input)
 ```
 
 ### No Test Runner Example

--- a/README.md
+++ b/README.md
@@ -8,14 +8,18 @@ $ pip install snappiershot
 
 ## Configuration
 SnappierShot is following the [trend of packages](https://github.com/carlosperate/awesome-pyproject/)
-in performing project-wide configuration through the pyproject.toml file established by
+in performing project-wide configuration through the `pyproject.toml` file established by
 [PEP 518](https://www.python.org/dev/peps/pep-0518/).
 
-Within the pyproject.toml file, all SnappierShot configuration can be found under the
-`[tool.snappiershot]` heading.
+Within the `pyproject.toml` file, all SnappierShot configuration can be found under the
+`[tool.snappiershot]` heading. While the `[tool.snappiershot]` heading is optional, the
+`[tool.poetry.plugins.pytest11]` heading must also be included.
 
 ### Example (with default values):
 ```toml
+[tool.poetry.plugins.pytest11]
+snappiershot = "snappiershot.plugins.pytest"
+
 [tool.snappiershot]
 file_format = "json"
 float_absolute_tolerance = 1e-6
@@ -24,18 +28,35 @@ full_diff = false
 json_indentation = 4
 ```
 
+Currently, the only allowed file format is JSON.
 
 ## Usage
 
 SnappierShot allows you to take a "snapshot" of data the first time that a test
-  is run, and stores it nearby in a `.snapshots` directory. Then, for all
-  subsequent times that test is run, the data is assert to "match" the original
+  is run, and stores it nearby in a `.snapshots` directory as a JSON. Then, for all
+  subsequent times that test is run, the data is asserted to "match" the original
   data.
 
-### Pytest Example
+SnappierShot uses metadata to find tests stored in each snapshot file. Metadata is
+  defined as the inputs to a test method.
+* If the metadata is not found, a new file is Written.
+* If the metadata is found, the contents of the snapshot are checked and can either Pass or Fail.
+* If a snapshot file is found but the test isn't run, then the test is marked as Unchecked
+
+### Best Practices
+* Do not run `assert_match` within a loop
+* Do not try to snapshot uninstantiated classes/objects or use them as inputs to a test method
+* If an unsupported object type cannot be snapshotted, see [CONTRIBUTING.md](CONTRIBUTING.md) for instructions on how to contribute to the project
+  * `__snapshot__` and `__snapshotskip__` are temporary workarounds that can be added to a custom object class to define user specific encoding instructions, but this feature is hacky and not robust yet
+
+
+### Pytest Examples
+Implementing this way will not properly source the snappiershot reference
 ```python
-def test_something(snapshot):
-    """ Test that something works as expected"""
+from snappiershot import Snapshot as Snappy
+
+def test_no_documentation(snapshot):
+    """ Will not attach proper SnappierShot documentation to assert_match """
     # Arrange
     x = 1
     y = 2
@@ -45,14 +66,9 @@ def test_something(snapshot):
 
     # Assert
     snapshot.assert_match(result)
-```
 
-### No Test Runner Example
-```python
-from snappiershot import Snapshot
-
-def test_something():
-    """ Test that something works as expected"""
+def test_documentation(snapshot: Snappy):
+    """ Will attach proper SnappierShot documentation to assert_match """
     # Arrange
     x = 1
     y = 2
@@ -61,14 +77,90 @@ def test_something():
     result = x + y
 
     # Assert
-    with Snapshot() as snapshot
-        snapshot.assert_match(result)
+    snapshot.assert_match(result)
 
-test_something()
+def test_ignore_metadata(snapshot: Snappy, ignored_input: str = "ignore me"):
+    """ Test that metadata gets ignored """
+    # Arrange
+    x = 1
+    y = 2
+
+    # Act
+    result = x + y
+
+    # Assert
+    snapshot.assert_match(result, ignore=["ignored_input"])
 ```
 
+### No Test Runner Example
+```python
+from snappiershot import Snapshot
+
+def test_no_pytest_runner():
+    """ Run test without pytest runner """
+    # Arrange
+    x = 1
+    y = 2
+
+    # Act
+    result = x + y
+
+    # Assert
+    with Snapshot() as snapshot:
+        snapshot.assert_match(result)
+```
+
+### Custom Encoding Example
+Warning: Use these methods is hacky and should not be relied on.
+
+
+* `__snapshot__` overrides serializing behavior for instanced custom objects
+* `__snapshotskip__` overrides serializing behavior for uninstanced custom objects
+
+```python
+from snappiershot import Snapshot as Snappy
+from pytest import fixture
+
+class CustomClass:
+  def __init__(self):
+    self.a = 1
+    self.b = 2
+
+  def __snapshot__(self):
+    encoding = {
+      "a": self.a,
+      "b": self.b,
+    }
+    return encoding
+
+  @classmethod
+  def __snapshotskip__(cls):
+    return "test string"
+
+
+@fixture
+def instanced_input() -> CustomClass:
+  instanced_input = CustomClass()
+  return instanced_input
+
+@fixture
+def uninstanced_input() -> type(CustomClass):
+  instanced_input = CustomClass
+  return instanced_input
+
+def test_class(uninstanced_input: type(CustomClass), instanced_input: CustomClass, snapshot: Snappy):
+    """ Test encoding snapshot and metadata for a custom class both instanced and un-instanced """
+
+    # Act
+    result = (instanced_input, uninstanced_input)
+
+    # Assert
+    snapshot.assert_match(result)
+```
+
+
 ### Raises
-Snappiershot also allows you to take a "snapshot" errors that are raised during
+Snappiershot also allows you to "snapshot" errors that are raised during
   the execution of a code block. This allows you to track how and when errors
   are reported more easily.
 
@@ -92,8 +184,9 @@ def test_fallible_function(snapshot):
   * Numerics (`complex`)
   * Collections (`lists`, `tuples`, `sets`)
   * Dictionaries
-  * Classes (with an underlying `__dict__`)
-  * Classes with custom encoding (by defining a `__snapshot__` method).
+  * Classes (with an underlying `__dict__`, `__slots__`, or `to_dict()`)
+  * Unit types from the `pint` package
+  * Classes with custom encoding (by defining a `__snapshot__` or `__snapshotskip__` method)
 
 ## Contributing
 See [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ SnappierShot uses metadata to find tests stored in each snapshot file. Metadata 
 ### Best Practices
 * Do not run `assert_match` within a loop
 * Do not try to snapshot uninstantiated classes/objects or use them as inputs to a test method
-* If an unsupported object type cannot be snapshotted, see [CONTRIBUTING.md](CONTRIBUTING.md) for instructions on how to contribute to the project
-  * `__snapshot__` and `__metadata_override__` are temporary workarounds that can be added to a custom object class to define user specific encoding instructions, but this feature is hacky and not robust yet
+* If an unsupported object type cannot be recorded, see [CONTRIBUTING.md](CONTRIBUTING.md) for instructions on how
+  to contribute to the project
+  * `__snapshot__` and `__metadata_override__` are temporary workarounds described below
 
 
 ### Pytest Examples
@@ -98,12 +99,15 @@ def test_no_pytest_runner():
         snapshot.assert_match(result)
 ```
 
-### Custom Encoding Example
+### Custom Encoding and Override Examples
 Warning: Use these methods is hacky and should not be relied on.
 
 
-* `__snapshot__` overrides serializing behavior for instanced custom objects
-* `__metadata_override__` overrides serializing behavior for uninstanced custom objects
+* `__snapshot__` overrides serializing behavior for objects being recorded
+  * Useful for partially recording class objects with many unnecessary properties
+* `__metadata_override__` overrides serializing behavior for metadata being recorded
+  * Useful for recording type objects (uninstantiated classes) via bypassing the default
+    encoding process
 
 ```python
 from snappiershot import Snapshot as Snappy
@@ -148,7 +152,7 @@ def test_class(uninstanced_input: type(CustomClass), instanced_input: CustomClas
 
 
 ### Raises
-Snappiershot also allows you to "snapshot" errors that are raised during
+Snappiershot also allows you to record errors that are raised during
   the execution of a code block. This allows you to track how and when errors
   are reported more easily.
 
@@ -172,7 +176,7 @@ def test_fallible_function(snapshot):
   * Numerics (`complex`)
   * Collections (`lists`, `tuples`, `sets`)
   * Dictionaries
-  * Classes (with an underlying `__dict__`, `__slots__`, or `to_dict()`)
+  * Classes (with an underlying `__dict__`, `__slots__`, or `to_dict`)
   * Unit types from the `pint` package
   * Classes with custom encoding (by defining a `__snapshot__` or `__metadata_override__` method)
 

--- a/README.md
+++ b/README.md
@@ -100,37 +100,59 @@ def test_no_pytest_runner():
 ```
 
 ### Custom Encoding and Override Examples
-Warning: Use of this method is currently still a little hacky
-
-* `__snapshot__` overrides serializing behavior for class objects being recorded
-  * Useful for partially recording class objects with many unnecessary properties
+`__snapshot__` overrides serializing behavior for class objects being recorded. Some of its potential use cases:
+  * Partially recording class objects with many unnecessary properties
+  * Skipping over encoding an object by returning a string
 
 ```python
 from snappiershot import Snapshot
 from pytest import fixture
 
-class CustomClass:
+class TestClass1:
   def __init__(self):
     self.a = 1
     self.b = 2
 
-  def __snapshot__(self):
+  def __snapshot__(self) -> dict:
     encoding = {
       "a": self.a,
       "b": self.b,
     }
     return encoding
 
-@fixture
-def class_input() -> CustomClass:
-  class_input = CustomClass()
-  return class_input
+class TestClass2:
+  def __init__(self):
+    self.a = 1
+    self.b = 2
 
-def test_class(class_input: CustomClass, snapshot: Snapshot):
-    """ Test encoding snapshot and metadata for a custom class """
+  def __snapshot__(self) -> str:
+    encoding = "ENCODING SKIPPED"
+    return encoding
+
+@fixture
+def class_input1() -> TestClass1:
+  class_input1 = TestClass1()
+  return class_input1
+
+@fixture
+def class_input2() -> TestClass2:
+  class_input2 = TestClass2()
+  return class_input2
+
+def test_class1(class_input1: TestClass1, snapshot: Snapshot):
+    """ Test encoding snapshot and metadata for a custom class with a dictionary override"""
 
     # Act
-    result = class_input
+    result = class_input1
+
+    # Assert
+    snapshot.assert_match(result)
+
+def test_class2(class_input2: TestClass2, snapshot: Snapshot):
+    """ Test encoding snapshot and metadata for a custom class with a string override """
+
+    # Act
+    result = class_input2
 
     # Assert
     snapshot.assert_match(result)

--- a/poetry.lock
+++ b/poetry.lock
@@ -473,7 +473,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "virtualenv"
-version = "20.13.4"
+version = "20.14.0"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
@@ -932,8 +932,8 @@ typing-extensions = [
     {file = "typing_extensions-4.1.1.tar.gz", hash = "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.13.4-py2.py3-none-any.whl", hash = "sha256:c3e01300fb8495bc00ed70741f5271fc95fed067eb7106297be73d30879af60c"},
-    {file = "virtualenv-20.13.4.tar.gz", hash = "sha256:ce8901d3bbf3b90393498187f2d56797a8a452fb2d0d7efc6fd837554d6f679c"},
+    {file = "virtualenv-20.14.0-py2.py3-none-any.whl", hash = "sha256:1e8588f35e8b42c6ec6841a13c5e88239de1e6e4e4cedfd3916b306dc826ec66"},
+    {file = "virtualenv-20.14.0.tar.gz", hash = "sha256:8e5b402037287126e81ccde9432b95a8be5b19d36584f64957060a3488c11ca8"},
 ]
 zipp = [
     {file = "zipp-3.6.0-py3-none-any.whl", hash = "sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -509,7 +509,7 @@ pandas = ["pandas"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.1"
-content-hash = "c6aecab25f4423580fde98ad882eda03e07e73ca94365dd11364a0558f401df0"
+content-hash = "21e25f0f93b51017115e539c589d5494f0fe7f3b034fbee1d6d0c6b3d58d7ec9"
 
 [metadata.files]
 appdirs = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -509,7 +509,7 @@ pandas = ["pandas"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.1"
-content-hash = "21e25f0f93b51017115e539c589d5494f0fe7f3b034fbee1d6d0c6b3d58d7ec9"
+content-hash = "c6aecab25f4423580fde98ad882eda03e07e73ca94365dd11364a0558f401df0"
 
 [metadata.files]
 appdirs = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,12 +1,4 @@
 [[package]]
-name = "appdirs"
-version = "1.4.4"
-description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
-category = "dev"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "atomicwrites"
 version = "1.4.0"
 description = "Atomic file writes."
@@ -30,23 +22,27 @@ tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>
 
 [[package]]
 name = "black"
-version = "19.10b0"
+version = "22.3.0"
 description = "The uncompromising code formatter."
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.6.2"
 
 [package.dependencies]
-appdirs = "*"
-attrs = ">=18.1.0"
-click = ">=6.5"
-pathspec = ">=0.6,<1"
-regex = "*"
-toml = ">=0.9.4"
-typed-ast = ">=1.4.0"
+click = ">=8.0.0"
+dataclasses = {version = ">=0.6", markers = "python_version < \"3.7\""}
+mypy-extensions = ">=0.4.3"
+pathspec = ">=0.9.0"
+platformdirs = ">=2"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+typed-ast = {version = ">=1.4.2", markers = "python_version < \"3.8\" and implementation_name == \"cpython\""}
+typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
-d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
+colorama = ["colorama (>=0.4.3)"]
+d = ["aiohttp (>=3.7.4)"]
+jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
+uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "cfgv"
@@ -86,6 +82,14 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 
 [package.extras]
 toml = ["toml"]
+
+[[package]]
+name = "dataclasses"
+version = "0.8"
+description = "A backport of the dataclasses module for Python 3.6"
+category = "dev"
+optional = false
+python-versions = ">=3.6, <3.7"
 
 [[package]]
 name = "distlib"
@@ -424,14 +428,6 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
-name = "regex"
-version = "2022.3.15"
-description = "Alternative regular expression module, to replace re."
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -446,6 +442,14 @@ description = "Python Library for Tom's Obvious, Minimal Language"
 category = "dev"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "tomli"
+version = "1.2.3"
+description = "A lil' TOML parser"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
 
 [[package]]
 name = "tomlkit"
@@ -508,14 +512,10 @@ pandas = ["pandas"]
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.6.1"
-content-hash = "c6aecab25f4423580fde98ad882eda03e07e73ca94365dd11364a0558f401df0"
+python-versions = "^3.6.2"
+content-hash = "defafbe72ebbb1300a0251e9c0f268556056cc9519e030776a86e3eda0c2df6a"
 
 [metadata.files]
-appdirs = [
-    {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
-    {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
-]
 atomicwrites = [
     {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
     {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
@@ -525,8 +525,29 @@ attrs = [
     {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
 ]
 black = [
-    {file = "black-19.10b0-py36-none-any.whl", hash = "sha256:1b30e59be925fafc1ee4565e5e08abef6b03fe455102883820fe5ee2e4734e0b"},
-    {file = "black-19.10b0.tar.gz", hash = "sha256:c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539"},
+    {file = "black-22.3.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:2497f9c2386572e28921fa8bec7be3e51de6801f7459dffd6e62492531c47e09"},
+    {file = "black-22.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5795a0375eb87bfe902e80e0c8cfaedf8af4d49694d69161e5bd3206c18618bb"},
+    {file = "black-22.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e3556168e2e5c49629f7b0f377070240bd5511e45e25a4497bb0073d9dda776a"},
+    {file = "black-22.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67c8301ec94e3bcc8906740fe071391bce40a862b7be0b86fb5382beefecd968"},
+    {file = "black-22.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:fd57160949179ec517d32ac2ac898b5f20d68ed1a9c977346efbac9c2f1e779d"},
+    {file = "black-22.3.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:cc1e1de68c8e5444e8f94c3670bb48a2beef0e91dddfd4fcc29595ebd90bb9ce"},
+    {file = "black-22.3.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d2fc92002d44746d3e7db7cf9313cf4452f43e9ea77a2c939defce3b10b5c82"},
+    {file = "black-22.3.0-cp36-cp36m-win_amd64.whl", hash = "sha256:a6342964b43a99dbc72f72812bf88cad8f0217ae9acb47c0d4f141a6416d2d7b"},
+    {file = "black-22.3.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:328efc0cc70ccb23429d6be184a15ce613f676bdfc85e5fe8ea2a9354b4e9015"},
+    {file = "black-22.3.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06f9d8846f2340dfac80ceb20200ea5d1b3f181dd0556b47af4e8e0b24fa0a6b"},
+    {file = "black-22.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:ad4efa5fad66b903b4a5f96d91461d90b9507a812b3c5de657d544215bb7877a"},
+    {file = "black-22.3.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:e8477ec6bbfe0312c128e74644ac8a02ca06bcdb8982d4ee06f209be28cdf163"},
+    {file = "black-22.3.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:637a4014c63fbf42a692d22b55d8ad6968a946b4a6ebc385c5505d9625b6a464"},
+    {file = "black-22.3.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:863714200ada56cbc366dc9ae5291ceb936573155f8bf8e9de92aef51f3ad0f0"},
+    {file = "black-22.3.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:10dbe6e6d2988049b4655b2b739f98785a884d4d6b85bc35133a8fb9a2233176"},
+    {file = "black-22.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:cee3e11161dde1b2a33a904b850b0899e0424cc331b7295f2a9698e79f9a69a0"},
+    {file = "black-22.3.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:5891ef8abc06576985de8fa88e95ab70641de6c1fca97e2a15820a9b69e51b20"},
+    {file = "black-22.3.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:30d78ba6bf080eeaf0b7b875d924b15cd46fec5fd044ddfbad38c8ea9171043a"},
+    {file = "black-22.3.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ee8f1f7228cce7dffc2b464f07ce769f478968bfb3dd1254a4c2eeed84928aad"},
+    {file = "black-22.3.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6ee227b696ca60dd1c507be80a6bc849a5a6ab57ac7352aad1ffec9e8b805f21"},
+    {file = "black-22.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:9b542ced1ec0ceeff5b37d69838106a6348e60db7b8fdd245294dc1d26136265"},
+    {file = "black-22.3.0-py3-none-any.whl", hash = "sha256:bc58025940a896d7e5356952228b68f793cf5fcb342be703c3a2669a1488cb72"},
+    {file = "black-22.3.0.tar.gz", hash = "sha256:35020b8886c022ced9282b51b5a875b6d1ab0c387b31a065b84db7c33085ca79"},
 ]
 cfgv = [
     {file = "cfgv-3.3.1-py2.py3-none-any.whl", hash = "sha256:c6a0883f3917a037485059700b9e75da2464e6c27051014ad85ba6aaa5884426"},
@@ -593,6 +614,10 @@ coverage = [
     {file = "coverage-5.5-pp36-none-any.whl", hash = "sha256:f030f8873312a16414c0d8e1a1ddff2d3235655a2174e3648b4fa66b3f2f1079"},
     {file = "coverage-5.5-pp37-none-any.whl", hash = "sha256:2a3859cb82dcbda1cfd3e6f71c27081d18aa251d20a17d87d26d4cd216fb0af4"},
     {file = "coverage-5.5.tar.gz", hash = "sha256:ebe78fe9a0e874362175b02371bdfbee64d8edc42a044253ddf4ee7d3c15212c"},
+]
+dataclasses = [
+    {file = "dataclasses-0.8-py3-none-any.whl", hash = "sha256:0201d89fa866f68c8ebd9d08ee6ff50c0b255f8ec63a71c16fda7af82bb887bf"},
+    {file = "dataclasses-0.8.tar.gz", hash = "sha256:8479067f342acf957dc82ec415d355ab5edb7e7646b90dc6e2fd1d96ad084c97"},
 ]
 distlib = [
     {file = "distlib-0.3.4-py2.py3-none-any.whl", hash = "sha256:6564fe0a8f51e734df6333d08b8b94d4ea8ee6b99b5ed50613f731fd4089f34b"},
@@ -807,82 +832,6 @@ pyyaml = [
     {file = "PyYAML-6.0-cp39-cp39-win_amd64.whl", hash = "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c"},
     {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
 ]
-regex = [
-    {file = "regex-2022.3.15-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:42eb13b93765c6698a5ab3bcd318d8c39bb42e5fa8a7fcf7d8d98923f3babdb1"},
-    {file = "regex-2022.3.15-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9beb03ff6fe509d6455971c2489dceb31687b38781206bcec8e68bdfcf5f1db2"},
-    {file = "regex-2022.3.15-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d0a5a1fdc9f148a8827d55b05425801acebeeefc9e86065c7ac8b8cc740a91ff"},
-    {file = "regex-2022.3.15-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cb374a2a4dba7c4be0b19dc7b1adc50e6c2c26c3369ac629f50f3c198f3743a4"},
-    {file = "regex-2022.3.15-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c33ce0c665dd325200209340a88438ba7a470bd5f09f7424e520e1a3ff835b52"},
-    {file = "regex-2022.3.15-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:04c09b9651fa814eeeb38e029dc1ae83149203e4eeb94e52bb868fadf64852bc"},
-    {file = "regex-2022.3.15-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ab5d89cfaf71807da93c131bb7a19c3e19eaefd613d14f3bce4e97de830b15df"},
-    {file = "regex-2022.3.15-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0e2630ae470d6a9f8e4967388c1eda4762706f5750ecf387785e0df63a4cc5af"},
-    {file = "regex-2022.3.15-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:df037c01d68d1958dad3463e2881d3638a0d6693483f58ad41001aa53a83fcea"},
-    {file = "regex-2022.3.15-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:940570c1a305bac10e8b2bc934b85a7709c649317dd16520471e85660275083a"},
-    {file = "regex-2022.3.15-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:7f63877c87552992894ea1444378b9c3a1d80819880ae226bb30b04789c0828c"},
-    {file = "regex-2022.3.15-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:3e265b388cc80c7c9c01bb4f26c9e536c40b2c05b7231fbb347381a2e1c8bf43"},
-    {file = "regex-2022.3.15-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:058054c7a54428d5c3e3739ac1e363dc9347d15e64833817797dc4f01fb94bb8"},
-    {file = "regex-2022.3.15-cp310-cp310-win32.whl", hash = "sha256:76435a92e444e5b8f346aed76801db1c1e5176c4c7e17daba074fbb46cb8d783"},
-    {file = "regex-2022.3.15-cp310-cp310-win_amd64.whl", hash = "sha256:174d964bc683b1e8b0970e1325f75e6242786a92a22cedb2a6ec3e4ae25358bd"},
-    {file = "regex-2022.3.15-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:6e1d8ed9e61f37881c8db383a124829a6e8114a69bd3377a25aecaeb9b3538f8"},
-    {file = "regex-2022.3.15-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b52771f05cff7517f7067fef19ffe545b1f05959e440d42247a17cd9bddae11b"},
-    {file = "regex-2022.3.15-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:673f5a393d603c34477dbad70db30025ccd23996a2d0916e942aac91cc42b31a"},
-    {file = "regex-2022.3.15-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8923e1c5231549fee78ff9b2914fad25f2e3517572bb34bfaa3aea682a758683"},
-    {file = "regex-2022.3.15-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:764e66a0e382829f6ad3bbce0987153080a511c19eb3d2f8ead3f766d14433ac"},
-    {file = "regex-2022.3.15-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cd00859291658fe1fda48a99559fb34da891c50385b0bfb35b808f98956ef1e7"},
-    {file = "regex-2022.3.15-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:aa2ce79f3889720b46e0aaba338148a1069aea55fda2c29e0626b4db20d9fcb7"},
-    {file = "regex-2022.3.15-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:34bb30c095342797608727baf5c8aa122406aa5edfa12107b8e08eb432d4c5d7"},
-    {file = "regex-2022.3.15-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:25ecb1dffc5e409ca42f01a2b2437f93024ff1612c1e7983bad9ee191a5e8828"},
-    {file = "regex-2022.3.15-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:aa5eedfc2461c16a092a2fabc5895f159915f25731740c9152a1b00f4bcf629a"},
-    {file = "regex-2022.3.15-cp36-cp36m-musllinux_1_1_s390x.whl", hash = "sha256:7d1a6e403ac8f1d91d8f51c441c3f99367488ed822bda2b40836690d5d0059f5"},
-    {file = "regex-2022.3.15-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:3e4d710ff6539026e49f15a3797c6b1053573c2b65210373ef0eec24480b900b"},
-    {file = "regex-2022.3.15-cp36-cp36m-win32.whl", hash = "sha256:0100f0ded953b6b17f18207907159ba9be3159649ad2d9b15535a74de70359d3"},
-    {file = "regex-2022.3.15-cp36-cp36m-win_amd64.whl", hash = "sha256:f320c070dea3f20c11213e56dbbd7294c05743417cde01392148964b7bc2d31a"},
-    {file = "regex-2022.3.15-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fc8c7958d14e8270171b3d72792b609c057ec0fa17d507729835b5cff6b7f69a"},
-    {file = "regex-2022.3.15-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ca6dcd17f537e9f3793cdde20ac6076af51b2bd8ad5fe69fa54373b17b48d3c"},
-    {file = "regex-2022.3.15-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0214ff6dff1b5a4b4740cfe6e47f2c4c92ba2938fca7abbea1359036305c132f"},
-    {file = "regex-2022.3.15-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a98ae493e4e80b3ded6503ff087a8492db058e9c68de371ac3df78e88360b374"},
-    {file = "regex-2022.3.15-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8b1cc70e31aacc152a12b39245974c8fccf313187eead559ee5966d50e1b5817"},
-    {file = "regex-2022.3.15-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b4829db3737480a9d5bfb1c0320c4ee13736f555f53a056aacc874f140e98f64"},
-    {file = "regex-2022.3.15-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:303b15a3d32bf5fe5a73288c316bac5807587f193ceee4eb6d96ee38663789fa"},
-    {file = "regex-2022.3.15-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:dc7b7c16a519d924c50876fb152af661a20749dcbf653c8759e715c1a7a95b18"},
-    {file = "regex-2022.3.15-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:ce3057777a14a9a1399b81eca6a6bfc9612047811234398b84c54aeff6d536ea"},
-    {file = "regex-2022.3.15-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:48081b6bff550fe10bcc20c01cf6c83dbca2ccf74eeacbfac240264775fd7ecf"},
-    {file = "regex-2022.3.15-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:dcbb7665a9db9f8d7642171152c45da60e16c4f706191d66a1dc47ec9f820aed"},
-    {file = "regex-2022.3.15-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:c155a1a80c5e7a8fa1d9bb1bf3c8a953532b53ab1196092749bafb9d3a7cbb60"},
-    {file = "regex-2022.3.15-cp37-cp37m-win32.whl", hash = "sha256:04b5ee2b6d29b4a99d38a6469aa1db65bb79d283186e8460542c517da195a8f6"},
-    {file = "regex-2022.3.15-cp37-cp37m-win_amd64.whl", hash = "sha256:797437e6024dc1589163675ae82f303103063a0a580c6fd8d0b9a0a6708da29e"},
-    {file = "regex-2022.3.15-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8afcd1c2297bc989dceaa0379ba15a6df16da69493635e53431d2d0c30356086"},
-    {file = "regex-2022.3.15-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:0066a6631c92774391f2ea0f90268f0d82fffe39cb946f0f9c6b382a1c61a5e5"},
-    {file = "regex-2022.3.15-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b8248f19a878c72d8c0a785a2cd45d69432e443c9f10ab924c29adda77b324ae"},
-    {file = "regex-2022.3.15-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8d1f3ea0d1924feb4cf6afb2699259f658a08ac6f8f3a4a806661c2dfcd66db1"},
-    {file = "regex-2022.3.15-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:794a6bc66c43db8ed06698fc32aaeaac5c4812d9f825e9589e56f311da7becd9"},
-    {file = "regex-2022.3.15-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4d1445824944e642ffa54c4f512da17a953699c563a356d8b8cbdad26d3b7598"},
-    {file = "regex-2022.3.15-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f553a1190ae6cd26e553a79f6b6cfba7b8f304da2071052fa33469da075ea625"},
-    {file = "regex-2022.3.15-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:75a5e6ce18982f0713c4bac0704bf3f65eed9b277edd3fb9d2b0ff1815943327"},
-    {file = "regex-2022.3.15-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:f16cf7e4e1bf88fecf7f41da4061f181a6170e179d956420f84e700fb8a3fd6b"},
-    {file = "regex-2022.3.15-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:dad3991f0678facca1a0831ec1ddece2eb4d1dd0f5150acb9440f73a3b863907"},
-    {file = "regex-2022.3.15-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:491fc754428514750ab21c2d294486223ce7385446f2c2f5df87ddbed32979ae"},
-    {file = "regex-2022.3.15-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:6504c22c173bb74075d7479852356bb7ca80e28c8e548d4d630a104f231e04fb"},
-    {file = "regex-2022.3.15-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:01c913cf573d1da0b34c9001a94977273b5ee2fe4cb222a5d5b320f3a9d1a835"},
-    {file = "regex-2022.3.15-cp38-cp38-win32.whl", hash = "sha256:029e9e7e0d4d7c3446aa92474cbb07dafb0b2ef1d5ca8365f059998c010600e6"},
-    {file = "regex-2022.3.15-cp38-cp38-win_amd64.whl", hash = "sha256:947a8525c0a95ba8dc873191f9017d1b1e3024d4dc757f694e0af3026e34044a"},
-    {file = "regex-2022.3.15-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:591d4fba554f24bfa0421ba040cd199210a24301f923ed4b628e1e15a1001ff4"},
-    {file = "regex-2022.3.15-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b9809404528a999cf02a400ee5677c81959bc5cb938fdc696b62eb40214e3632"},
-    {file = "regex-2022.3.15-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f08a7e4d62ea2a45557f561eea87c907222575ca2134180b6974f8ac81e24f06"},
-    {file = "regex-2022.3.15-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5a86cac984da35377ca9ac5e2e0589bd11b3aebb61801204bd99c41fac516f0d"},
-    {file = "regex-2022.3.15-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:286908cbe86b1a0240a867aecfe26a439b16a1f585d2de133540549831f8e774"},
-    {file = "regex-2022.3.15-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b7494df3fdcc95a1f76cf134d00b54962dd83189520fd35b8fcd474c0aa616d"},
-    {file = "regex-2022.3.15-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5b1ceede92400b3acfebc1425937454aaf2c62cd5261a3fabd560c61e74f6da3"},
-    {file = "regex-2022.3.15-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0317eb6331146c524751354ebef76a7a531853d7207a4d760dfb5f553137a2a4"},
-    {file = "regex-2022.3.15-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:9c144405220c5ad3f5deab4c77f3e80d52e83804a6b48b6bed3d81a9a0238e4c"},
-    {file = "regex-2022.3.15-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:5b2e24f3ae03af3d8e8e6d824c891fea0ca9035c5d06ac194a2700373861a15c"},
-    {file = "regex-2022.3.15-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:f2c53f3af011393ab5ed9ab640fa0876757498aac188f782a0c620e33faa2a3d"},
-    {file = "regex-2022.3.15-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:060f9066d2177905203516c62c8ea0066c16c7342971d54204d4e51b13dfbe2e"},
-    {file = "regex-2022.3.15-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:530a3a16e57bd3ea0dff5ec2695c09632c9d6c549f5869d6cf639f5f7153fb9c"},
-    {file = "regex-2022.3.15-cp39-cp39-win32.whl", hash = "sha256:78ce90c50d0ec970bd0002462430e00d1ecfd1255218d52d08b3a143fe4bde18"},
-    {file = "regex-2022.3.15-cp39-cp39-win_amd64.whl", hash = "sha256:c5adc854764732dbd95a713f2e6c3e914e17f2ccdc331b9ecb777484c31f73b6"},
-    {file = "regex-2022.3.15.tar.gz", hash = "sha256:0a7b75cc7bb4cc0334380053e4671c560e31272c9d2d5a6c4b8e9ae2c9bd0f82"},
-]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
@@ -890,6 +839,10 @@ six = [
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
+tomli = [
+    {file = "tomli-1.2.3-py3-none-any.whl", hash = "sha256:e3069e4be3ead9668e21cb9b074cd948f7b3113fd9c8bba083f48247aab8b11c"},
+    {file = "tomli-1.2.3.tar.gz", hash = "sha256:05b6166bff487dc068d322585c7ea4ef78deed501cc124060e0f238e89a9231f"},
 ]
 tomlkit = [
     {file = "tomlkit-0.7.2-py2.py3-none-any.whl", hash = "sha256:173ad840fa5d2aac140528ca1933c29791b79a374a0861a80347f42ec9328117"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -16,17 +16,17 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "attrs"
-version = "20.3.0"
+version = "21.4.0"
 description = "Classes Without Boilerplate"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "furo", "sphinx", "pre-commit"]
-docs = ["furo", "sphinx", "zope.interface"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
-tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
+docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
 name = "black"
@@ -50,7 +50,7 @@ d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
 
 [[package]]
 name = "cfgv"
-version = "3.2.0"
+version = "3.3.1"
 description = "Validate configuration and produce human readable error messages."
 category = "dev"
 optional = false
@@ -58,11 +58,15 @@ python-versions = ">=3.6.1"
 
 [[package]]
 name = "click"
-version = "7.1.2"
+version = "8.0.4"
 description = "Composable command line interface toolkit"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.6"
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "colorama"
@@ -74,7 +78,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "coverage"
-version = "5.3"
+version = "5.5"
 description = "Code coverage measurement for Python"
 category = "dev"
 optional = false
@@ -85,7 +89,7 @@ toml = ["toml"]
 
 [[package]]
 name = "distlib"
-version = "0.3.1"
+version = "0.3.4"
 description = "Distribution utilities"
 category = "dev"
 optional = false
@@ -93,65 +97,72 @@ python-versions = "*"
 
 [[package]]
 name = "filelock"
-version = "3.0.12"
+version = "3.4.1"
 description = "A platform independent file lock."
 category = "dev"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6"
+
+[package.extras]
+docs = ["furo (>=2021.8.17b43)", "sphinx (>=4.1)", "sphinx-autodoc-typehints (>=1.12)"]
+testing = ["covdefaults (>=1.2.0)", "coverage (>=4)", "pytest (>=4)", "pytest-cov", "pytest-timeout (>=1.4.2)"]
 
 [[package]]
 name = "flake8"
-version = "3.8.4"
+version = "3.9.2"
 description = "the modular source code checker: pep8 pyflakes and co"
 category = "dev"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [package.dependencies]
 importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 mccabe = ">=0.6.0,<0.7.0"
-pycodestyle = ">=2.6.0a1,<2.7.0"
-pyflakes = ">=2.2.0,<2.3.0"
+pycodestyle = ">=2.7.0,<2.8.0"
+pyflakes = ">=2.3.0,<2.4.0"
 
 [[package]]
 name = "identify"
-version = "1.5.10"
+version = "2.4.4"
 description = "File identification library for Python"
 category = "dev"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+python-versions = ">=3.6.1"
 
 [package.extras]
-license = ["editdistance"]
+license = ["ukkonen"]
 
 [[package]]
 name = "importlib-metadata"
-version = "3.1.0"
+version = "4.8.3"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
+typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
 
 [package.extras]
-docs = ["sphinx", "rst.linker"]
-testing = ["packaging", "pep517", "unittest2", "importlib-resources (>=1.3)"]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+perf = ["ipython"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "importlib-resources"
-version = "3.3.0"
+version = "5.2.3"
 description = "Read resources from Python packages"
 category = "dev"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
+python-versions = ">=3.6"
 
 [package.dependencies]
-zipp = {version = ">=0.4", markers = "python_version < \"3.8\""}
+zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
-docs = ["sphinx", "rst.linker", "jaraco.packaging"]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [[package]]
 name = "iniconfig"
@@ -195,7 +206,7 @@ python-versions = "*"
 
 [[package]]
 name = "nodeenv"
-version = "1.5.0"
+version = "1.6.0"
 description = "Node.js virtual environment builder"
 category = "dev"
 optional = false
@@ -203,7 +214,7 @@ python-versions = "*"
 
 [[package]]
 name = "numpy"
-version = "1.19.4"
+version = "1.19.5"
 description = "NumPy is the fundamental package for array computing with Python."
 category = "main"
 optional = false
@@ -211,19 +222,18 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "packaging"
-version = "20.4"
+version = "21.3"
 description = "Core utilities for Python packages"
-category = "dev"
+category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.6"
 
 [package.dependencies]
-pyparsing = ">=2.0.2"
-six = "*"
+pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
 name = "pandas"
-version = "1.1.4"
+version = "1.1.5"
 description = "Powerful data structures for data analysis, time series, and statistics"
 category = "main"
 optional = false
@@ -239,25 +249,55 @@ test = ["pytest (>=4.0.2)", "pytest-xdist", "hypothesis (>=3.58)"]
 
 [[package]]
 name = "pathspec"
-version = "0.8.1"
+version = "0.9.0"
 description = "Utility library for gitignore style pattern matching of file paths."
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[[package]]
+name = "pint"
+version = "0.14"
+description = "Physical quantities module"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+packaging = "*"
+
+[package.extras]
+numpy = ["numpy (>=1.14)"]
+test = ["pytest", "pytest-mpl", "pytest-cov"]
+uncertainties = ["uncertainties (>=3.0)"]
+
+[[package]]
+name = "platformdirs"
+version = "2.4.0"
+description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+docs = ["Sphinx (>=4)", "furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)"]
+test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)"]
 
 [[package]]
 name = "pluggy"
-version = "0.13.1"
+version = "1.0.0"
 description = "plugin and hook calling mechanisms for python"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.6"
 
 [package.dependencies]
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
 dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pprint-ordered-sets"
@@ -269,7 +309,7 @@ python-versions = ">=3.6.1,<4.0.0"
 
 [[package]]
 name = "pre-commit"
-version = "2.9.0"
+version = "2.17.0"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
 category = "dev"
 optional = false
@@ -279,7 +319,7 @@ python-versions = ">=3.6.1"
 cfgv = ">=2.0.0"
 identify = ">=1.0.0"
 importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
-importlib-resources = {version = "*", markers = "python_version < \"3.7\""}
+importlib-resources = {version = "<5.3", markers = "python_version < \"3.7\""}
 nodeenv = ">=0.11.1"
 pyyaml = ">=5.1"
 toml = "*"
@@ -287,15 +327,15 @@ virtualenv = ">=20.0.8"
 
 [[package]]
 name = "py"
-version = "1.9.0"
+version = "1.11.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "pycodestyle"
-version = "2.6.0"
+version = "2.7.0"
 description = "Python style guide checker"
 category = "dev"
 optional = false
@@ -303,7 +343,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pyflakes"
-version = "2.2.0"
+version = "2.3.1"
 description = "passive checker of Python programs"
 category = "dev"
 optional = false
@@ -311,42 +351,44 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pyparsing"
-version = "2.4.7"
+version = "3.0.7"
 description = "Python parsing module"
-category = "dev"
+category = "main"
 optional = false
-python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+python-versions = ">=3.6"
+
+[package.extras]
+diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pytest"
-version = "6.1.2"
+version = "6.2.5"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.6"
 
 [package.dependencies]
 atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
-attrs = ">=17.4.0"
+attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 iniconfig = "*"
 packaging = "*"
-pluggy = ">=0.12,<1.0"
+pluggy = ">=0.12,<2.0"
 py = ">=1.8.2"
 toml = "*"
 
 [package.extras]
-checkqa_mypy = ["mypy (==0.780)"]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
 name = "pytest-mock"
-version = "3.3.1"
+version = "3.6.1"
 description = "Thin-wrapper around the mock package for easier use with pytest"
 category = "dev"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.6"
 
 [package.dependencies]
 pytest = ">=5.0"
@@ -356,7 +398,7 @@ dev = ["pre-commit", "tox", "pytest-asyncio"]
 
 [[package]]
 name = "python-dateutil"
-version = "2.8.1"
+version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
 category = "main"
 optional = false
@@ -367,7 +409,7 @@ six = ">=1.5"
 
 [[package]]
 name = "pytz"
-version = "2020.4"
+version = "2022.1"
 description = "World timezone definitions, modern and historical"
 category = "main"
 optional = false
@@ -375,23 +417,23 @@ python-versions = "*"
 
 [[package]]
 name = "pyyaml"
-version = "5.3.1"
+version = "6.0"
 description = "YAML parser and emitter for Python"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.6"
 
 [[package]]
 name = "regex"
-version = "2020.11.13"
+version = "2022.3.15"
 description = "Alternative regular expression module, to replace re."
 category = "dev"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6"
 
 [[package]]
 name = "six"
-version = "1.15.0"
+version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
 category = "main"
 optional = false
@@ -407,7 +449,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "tomlkit"
-version = "0.7.0"
+version = "0.7.2"
 description = "Style preserving TOML library"
 category = "main"
 optional = false
@@ -415,7 +457,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "typed-ast"
-version = "1.4.1"
+version = "1.4.3"
 description = "a fork of Python 2 and 3 ast modules with type comment support"
 category = "dev"
 optional = false
@@ -423,43 +465,43 @@ python-versions = "*"
 
 [[package]]
 name = "typing-extensions"
-version = "3.7.4.3"
-description = "Backported and Experimental Type Hints for Python 3.5+"
-category = "dev"
+version = "4.1.1"
+description = "Backported and Experimental Type Hints for Python 3.6+"
+category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6"
 
 [[package]]
 name = "virtualenv"
-version = "20.2.1"
+version = "20.13.4"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [package.dependencies]
-appdirs = ">=1.4.3,<2"
 distlib = ">=0.3.1,<1"
-filelock = ">=3.0.0,<4"
+filelock = ">=3.2,<4"
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 importlib-resources = {version = ">=1.0", markers = "python_version < \"3.7\""}
+platformdirs = ">=2,<3"
 six = ">=1.9.0,<2"
 
 [package.extras]
-docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=19.9.0rc1)"]
-testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)", "pytest-xdist (>=1.31.0)", "packaging (>=20.0)", "xonsh (>=0.9.16)"]
+docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=21.3)"]
+testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)", "packaging (>=20.0)"]
 
 [[package]]
 name = "zipp"
-version = "3.4.0"
+version = "3.6.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [extras]
 pandas = ["pandas"]
@@ -467,7 +509,7 @@ pandas = ["pandas"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.1"
-content-hash = "8f08f97205e005de4076c871e2a7c9cb61ad6d0733b3756cc831c86715a5e6f5"
+content-hash = "c6aecab25f4423580fde98ad882eda03e07e73ca94365dd11364a0558f401df0"
 
 [metadata.files]
 appdirs = [
@@ -479,84 +521,102 @@ atomicwrites = [
     {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
 ]
 attrs = [
-    {file = "attrs-20.3.0-py2.py3-none-any.whl", hash = "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6"},
-    {file = "attrs-20.3.0.tar.gz", hash = "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"},
+    {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
+    {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
 ]
 black = [
     {file = "black-19.10b0-py36-none-any.whl", hash = "sha256:1b30e59be925fafc1ee4565e5e08abef6b03fe455102883820fe5ee2e4734e0b"},
     {file = "black-19.10b0.tar.gz", hash = "sha256:c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539"},
 ]
 cfgv = [
-    {file = "cfgv-3.2.0-py2.py3-none-any.whl", hash = "sha256:32e43d604bbe7896fe7c248a9c2276447dbef840feb28fe20494f62af110211d"},
-    {file = "cfgv-3.2.0.tar.gz", hash = "sha256:cf22deb93d4bcf92f345a5c3cd39d3d41d6340adc60c78bbbd6588c384fda6a1"},
+    {file = "cfgv-3.3.1-py2.py3-none-any.whl", hash = "sha256:c6a0883f3917a037485059700b9e75da2464e6c27051014ad85ba6aaa5884426"},
+    {file = "cfgv-3.3.1.tar.gz", hash = "sha256:f5a830efb9ce7a445376bb66ec94c638a9787422f96264c98edc6bdeed8ab736"},
 ]
 click = [
-    {file = "click-7.1.2-py2.py3-none-any.whl", hash = "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"},
-    {file = "click-7.1.2.tar.gz", hash = "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a"},
+    {file = "click-8.0.4-py3-none-any.whl", hash = "sha256:6a7a62563bbfabfda3a38f3023a1db4a35978c0abd76f6c9605ecd6554d6d9b1"},
+    {file = "click-8.0.4.tar.gz", hash = "sha256:8458d7b1287c5fb128c90e23381cf99dcde74beaf6c7ff6384ce84d6fe090adb"},
 ]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 coverage = [
-    {file = "coverage-5.3-cp27-cp27m-macosx_10_13_intel.whl", hash = "sha256:bd3166bb3b111e76a4f8e2980fa1addf2920a4ca9b2b8ca36a3bc3dedc618270"},
-    {file = "coverage-5.3-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:9342dd70a1e151684727c9c91ea003b2fb33523bf19385d4554f7897ca0141d4"},
-    {file = "coverage-5.3-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:63808c30b41f3bbf65e29f7280bf793c79f54fb807057de7e5238ffc7cc4d7b9"},
-    {file = "coverage-5.3-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:4d6a42744139a7fa5b46a264874a781e8694bb32f1d76d8137b68138686f1729"},
-    {file = "coverage-5.3-cp27-cp27m-win32.whl", hash = "sha256:86e9f8cd4b0cdd57b4ae71a9c186717daa4c5a99f3238a8723f416256e0b064d"},
-    {file = "coverage-5.3-cp27-cp27m-win_amd64.whl", hash = "sha256:7858847f2d84bf6e64c7f66498e851c54de8ea06a6f96a32a1d192d846734418"},
-    {file = "coverage-5.3-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:530cc8aaf11cc2ac7430f3614b04645662ef20c348dce4167c22d99bec3480e9"},
-    {file = "coverage-5.3-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:381ead10b9b9af5f64646cd27107fb27b614ee7040bb1226f9c07ba96625cbb5"},
-    {file = "coverage-5.3-cp35-cp35m-macosx_10_13_x86_64.whl", hash = "sha256:71b69bd716698fa62cd97137d6f2fdf49f534decb23a2c6fc80813e8b7be6822"},
-    {file = "coverage-5.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:1d44bb3a652fed01f1f2c10d5477956116e9b391320c94d36c6bf13b088a1097"},
-    {file = "coverage-5.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:1c6703094c81fa55b816f5ae542c6ffc625fec769f22b053adb42ad712d086c9"},
-    {file = "coverage-5.3-cp35-cp35m-win32.whl", hash = "sha256:cedb2f9e1f990918ea061f28a0f0077a07702e3819602d3507e2ff98c8d20636"},
-    {file = "coverage-5.3-cp35-cp35m-win_amd64.whl", hash = "sha256:7f43286f13d91a34fadf61ae252a51a130223c52bfefb50310d5b2deb062cf0f"},
-    {file = "coverage-5.3-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:c851b35fc078389bc16b915a0a7c1d5923e12e2c5aeec58c52f4aa8085ac8237"},
-    {file = "coverage-5.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:aac1ba0a253e17889550ddb1b60a2063f7474155465577caa2a3b131224cfd54"},
-    {file = "coverage-5.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:2b31f46bf7b31e6aa690d4c7a3d51bb262438c6dcb0d528adde446531d0d3bb7"},
-    {file = "coverage-5.3-cp36-cp36m-win32.whl", hash = "sha256:c5f17ad25d2c1286436761b462e22b5020d83316f8e8fcb5deb2b3151f8f1d3a"},
-    {file = "coverage-5.3-cp36-cp36m-win_amd64.whl", hash = "sha256:aef72eae10b5e3116bac6957de1df4d75909fc76d1499a53fb6387434b6bcd8d"},
-    {file = "coverage-5.3-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:e8caf961e1b1a945db76f1b5fa9c91498d15f545ac0ababbe575cfab185d3bd8"},
-    {file = "coverage-5.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:29a6272fec10623fcbe158fdf9abc7a5fa032048ac1d8631f14b50fbfc10d17f"},
-    {file = "coverage-5.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:2d43af2be93ffbad25dd959899b5b809618a496926146ce98ee0b23683f8c51c"},
-    {file = "coverage-5.3-cp37-cp37m-win32.whl", hash = "sha256:c3888a051226e676e383de03bf49eb633cd39fc829516e5334e69b8d81aae751"},
-    {file = "coverage-5.3-cp37-cp37m-win_amd64.whl", hash = "sha256:9669179786254a2e7e57f0ecf224e978471491d660aaca833f845b72a2df3709"},
-    {file = "coverage-5.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0203acd33d2298e19b57451ebb0bed0ab0c602e5cf5a818591b4918b1f97d516"},
-    {file = "coverage-5.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:582ddfbe712025448206a5bc45855d16c2e491c2dd102ee9a2841418ac1c629f"},
-    {file = "coverage-5.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:0f313707cdecd5cd3e217fc68c78a960b616604b559e9ea60cc16795c4304259"},
-    {file = "coverage-5.3-cp38-cp38-win32.whl", hash = "sha256:78e93cc3571fd928a39c0b26767c986188a4118edc67bc0695bc7a284da22e82"},
-    {file = "coverage-5.3-cp38-cp38-win_amd64.whl", hash = "sha256:8f264ba2701b8c9f815b272ad568d555ef98dfe1576802ab3149c3629a9f2221"},
-    {file = "coverage-5.3-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:50691e744714856f03a86df3e2bff847c2acede4c191f9a1da38f088df342978"},
-    {file = "coverage-5.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:9361de40701666b034c59ad9e317bae95c973b9ff92513dd0eced11c6adf2e21"},
-    {file = "coverage-5.3-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:c1b78fb9700fc961f53386ad2fd86d87091e06ede5d118b8a50dea285a071c24"},
-    {file = "coverage-5.3-cp39-cp39-win32.whl", hash = "sha256:cb7df71de0af56000115eafd000b867d1261f786b5eebd88a0ca6360cccfaca7"},
-    {file = "coverage-5.3-cp39-cp39-win_amd64.whl", hash = "sha256:47a11bdbd8ada9b7ee628596f9d97fbd3851bd9999d398e9436bd67376dbece7"},
-    {file = "coverage-5.3.tar.gz", hash = "sha256:280baa8ec489c4f542f8940f9c4c2181f0306a8ee1a54eceba071a449fb870a0"},
+    {file = "coverage-5.5-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:b6d534e4b2ab35c9f93f46229363e17f63c53ad01330df9f2d6bd1187e5eaacf"},
+    {file = "coverage-5.5-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:b7895207b4c843c76a25ab8c1e866261bcfe27bfaa20c192de5190121770672b"},
+    {file = "coverage-5.5-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:c2723d347ab06e7ddad1a58b2a821218239249a9e4365eaff6649d31180c1669"},
+    {file = "coverage-5.5-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:900fbf7759501bc7807fd6638c947d7a831fc9fdf742dc10f02956ff7220fa90"},
+    {file = "coverage-5.5-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:004d1880bed2d97151facef49f08e255a20ceb6f9432df75f4eef018fdd5a78c"},
+    {file = "coverage-5.5-cp27-cp27m-win32.whl", hash = "sha256:06191eb60f8d8a5bc046f3799f8a07a2d7aefb9504b0209aff0b47298333302a"},
+    {file = "coverage-5.5-cp27-cp27m-win_amd64.whl", hash = "sha256:7501140f755b725495941b43347ba8a2777407fc7f250d4f5a7d2a1050ba8e82"},
+    {file = "coverage-5.5-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:372da284cfd642d8e08ef606917846fa2ee350f64994bebfbd3afb0040436905"},
+    {file = "coverage-5.5-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:8963a499849a1fc54b35b1c9f162f4108017b2e6db2c46c1bed93a72262ed083"},
+    {file = "coverage-5.5-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:869a64f53488f40fa5b5b9dcb9e9b2962a66a87dab37790f3fcfb5144b996ef5"},
+    {file = "coverage-5.5-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:4a7697d8cb0f27399b0e393c0b90f0f1e40c82023ea4d45d22bce7032a5d7b81"},
+    {file = "coverage-5.5-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:8d0a0725ad7c1a0bcd8d1b437e191107d457e2ec1084b9f190630a4fb1af78e6"},
+    {file = "coverage-5.5-cp310-cp310-manylinux1_x86_64.whl", hash = "sha256:51cb9476a3987c8967ebab3f0fe144819781fca264f57f89760037a2ea191cb0"},
+    {file = "coverage-5.5-cp310-cp310-win_amd64.whl", hash = "sha256:c0891a6a97b09c1f3e073a890514d5012eb256845c451bd48f7968ef939bf4ae"},
+    {file = "coverage-5.5-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:3487286bc29a5aa4b93a072e9592f22254291ce96a9fbc5251f566b6b7343cdb"},
+    {file = "coverage-5.5-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:deee1077aae10d8fa88cb02c845cfba9b62c55e1183f52f6ae6a2df6a2187160"},
+    {file = "coverage-5.5-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:f11642dddbb0253cc8853254301b51390ba0081750a8ac03f20ea8103f0c56b6"},
+    {file = "coverage-5.5-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:6c90e11318f0d3c436a42409f2749ee1a115cd8b067d7f14c148f1ce5574d701"},
+    {file = "coverage-5.5-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:30c77c1dc9f253283e34c27935fded5015f7d1abe83bc7821680ac444eaf7793"},
+    {file = "coverage-5.5-cp35-cp35m-win32.whl", hash = "sha256:9a1ef3b66e38ef8618ce5fdc7bea3d9f45f3624e2a66295eea5e57966c85909e"},
+    {file = "coverage-5.5-cp35-cp35m-win_amd64.whl", hash = "sha256:972c85d205b51e30e59525694670de6a8a89691186012535f9d7dbaa230e42c3"},
+    {file = "coverage-5.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:af0e781009aaf59e25c5a678122391cb0f345ac0ec272c7961dc5455e1c40066"},
+    {file = "coverage-5.5-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:74d881fc777ebb11c63736622b60cb9e4aee5cace591ce274fb69e582a12a61a"},
+    {file = "coverage-5.5-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:92b017ce34b68a7d67bd6d117e6d443a9bf63a2ecf8567bb3d8c6c7bc5014465"},
+    {file = "coverage-5.5-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:d636598c8305e1f90b439dbf4f66437de4a5e3c31fdf47ad29542478c8508bbb"},
+    {file = "coverage-5.5-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:41179b8a845742d1eb60449bdb2992196e211341818565abded11cfa90efb821"},
+    {file = "coverage-5.5-cp36-cp36m-win32.whl", hash = "sha256:040af6c32813fa3eae5305d53f18875bedd079960822ef8ec067a66dd8afcd45"},
+    {file = "coverage-5.5-cp36-cp36m-win_amd64.whl", hash = "sha256:5fec2d43a2cc6965edc0bb9e83e1e4b557f76f843a77a2496cbe719583ce8184"},
+    {file = "coverage-5.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:18ba8bbede96a2c3dde7b868de9dcbd55670690af0988713f0603f037848418a"},
+    {file = "coverage-5.5-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:2910f4d36a6a9b4214bb7038d537f015346f413a975d57ca6b43bf23d6563b53"},
+    {file = "coverage-5.5-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:f0b278ce10936db1a37e6954e15a3730bea96a0997c26d7fee88e6c396c2086d"},
+    {file = "coverage-5.5-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:796c9c3c79747146ebd278dbe1e5c5c05dd6b10cc3bcb8389dfdf844f3ead638"},
+    {file = "coverage-5.5-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:53194af30d5bad77fcba80e23a1441c71abfb3e01192034f8246e0d8f99528f3"},
+    {file = "coverage-5.5-cp37-cp37m-win32.whl", hash = "sha256:184a47bbe0aa6400ed2d41d8e9ed868b8205046518c52464fde713ea06e3a74a"},
+    {file = "coverage-5.5-cp37-cp37m-win_amd64.whl", hash = "sha256:2949cad1c5208b8298d5686d5a85b66aae46d73eec2c3e08c817dd3513e5848a"},
+    {file = "coverage-5.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:217658ec7187497e3f3ebd901afdca1af062b42cfe3e0dafea4cced3983739f6"},
+    {file = "coverage-5.5-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1aa846f56c3d49205c952d8318e76ccc2ae23303351d9270ab220004c580cfe2"},
+    {file = "coverage-5.5-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:24d4a7de75446be83244eabbff746d66b9240ae020ced65d060815fac3423759"},
+    {file = "coverage-5.5-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:d1f8bf7b90ba55699b3a5e44930e93ff0189aa27186e96071fac7dd0d06a1873"},
+    {file = "coverage-5.5-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:970284a88b99673ccb2e4e334cfb38a10aab7cd44f7457564d11898a74b62d0a"},
+    {file = "coverage-5.5-cp38-cp38-win32.whl", hash = "sha256:01d84219b5cdbfc8122223b39a954820929497a1cb1422824bb86b07b74594b6"},
+    {file = "coverage-5.5-cp38-cp38-win_amd64.whl", hash = "sha256:2e0d881ad471768bf6e6c2bf905d183543f10098e3b3640fc029509530091502"},
+    {file = "coverage-5.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d1f9ce122f83b2305592c11d64f181b87153fc2c2bbd3bb4a3dde8303cfb1a6b"},
+    {file = "coverage-5.5-cp39-cp39-manylinux1_i686.whl", hash = "sha256:13c4ee887eca0f4c5a247b75398d4114c37882658300e153113dafb1d76de529"},
+    {file = "coverage-5.5-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:52596d3d0e8bdf3af43db3e9ba8dcdaac724ba7b5ca3f6358529d56f7a166f8b"},
+    {file = "coverage-5.5-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:2cafbbb3af0733db200c9b5f798d18953b1a304d3f86a938367de1567f4b5bff"},
+    {file = "coverage-5.5-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:44d654437b8ddd9eee7d1eaee28b7219bec228520ff809af170488fd2fed3e2b"},
+    {file = "coverage-5.5-cp39-cp39-win32.whl", hash = "sha256:d314ed732c25d29775e84a960c3c60808b682c08d86602ec2c3008e1202e3bb6"},
+    {file = "coverage-5.5-cp39-cp39-win_amd64.whl", hash = "sha256:13034c4409db851670bc9acd836243aeee299949bd5673e11844befcb0149f03"},
+    {file = "coverage-5.5-pp36-none-any.whl", hash = "sha256:f030f8873312a16414c0d8e1a1ddff2d3235655a2174e3648b4fa66b3f2f1079"},
+    {file = "coverage-5.5-pp37-none-any.whl", hash = "sha256:2a3859cb82dcbda1cfd3e6f71c27081d18aa251d20a17d87d26d4cd216fb0af4"},
+    {file = "coverage-5.5.tar.gz", hash = "sha256:ebe78fe9a0e874362175b02371bdfbee64d8edc42a044253ddf4ee7d3c15212c"},
 ]
 distlib = [
-    {file = "distlib-0.3.1-py2.py3-none-any.whl", hash = "sha256:8c09de2c67b3e7deef7184574fc060ab8a793e7adbb183d942c389c8b13c52fb"},
-    {file = "distlib-0.3.1.zip", hash = "sha256:edf6116872c863e1aa9d5bb7cb5e05a022c519a4594dc703843343a9ddd9bff1"},
+    {file = "distlib-0.3.4-py2.py3-none-any.whl", hash = "sha256:6564fe0a8f51e734df6333d08b8b94d4ea8ee6b99b5ed50613f731fd4089f34b"},
+    {file = "distlib-0.3.4.zip", hash = "sha256:e4b58818180336dc9c529bfb9a0b58728ffc09ad92027a3f30b7cd91e3458579"},
 ]
 filelock = [
-    {file = "filelock-3.0.12-py3-none-any.whl", hash = "sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836"},
-    {file = "filelock-3.0.12.tar.gz", hash = "sha256:18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59"},
+    {file = "filelock-3.4.1-py3-none-any.whl", hash = "sha256:a4bc51381e01502a30e9f06dd4fa19a1712eab852b6fb0f84fd7cce0793d8ca3"},
+    {file = "filelock-3.4.1.tar.gz", hash = "sha256:0f12f552b42b5bf60dba233710bf71337d35494fc8bdd4fd6d9f6d082ad45e06"},
 ]
 flake8 = [
-    {file = "flake8-3.8.4-py2.py3-none-any.whl", hash = "sha256:749dbbd6bfd0cf1318af27bf97a14e28e5ff548ef8e5b1566ccfb25a11e7c839"},
-    {file = "flake8-3.8.4.tar.gz", hash = "sha256:aadae8761ec651813c24be05c6f7b4680857ef6afaae4651a4eccaef97ce6c3b"},
+    {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},
+    {file = "flake8-3.9.2.tar.gz", hash = "sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b"},
 ]
 identify = [
-    {file = "identify-1.5.10-py2.py3-none-any.whl", hash = "sha256:cc86e6a9a390879dcc2976cef169dd9cc48843ed70b7380f321d1b118163c60e"},
-    {file = "identify-1.5.10.tar.gz", hash = "sha256:943cd299ac7f5715fcb3f684e2fc1594c1e0f22a90d15398e5888143bd4144b5"},
+    {file = "identify-2.4.4-py2.py3-none-any.whl", hash = "sha256:aa68609c7454dbcaae60a01ff6b8df1de9b39fe6e50b1f6107ec81dcda624aa6"},
+    {file = "identify-2.4.4.tar.gz", hash = "sha256:6b4b5031f69c48bf93a646b90de9b381c6b5f560df4cbe0ed3cf7650ae741e4d"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-3.1.0-py2.py3-none-any.whl", hash = "sha256:590690d61efdd716ff82c39ca9a9d4209252adfe288a4b5721181050acbd4175"},
-    {file = "importlib_metadata-3.1.0.tar.gz", hash = "sha256:d9b8a46a0885337627a6430db287176970fff18ad421becec1d64cfc763c2099"},
+    {file = "importlib_metadata-4.8.3-py3-none-any.whl", hash = "sha256:65a9576a5b2d58ca44d133c42a241905cc45e34d2c06fd5ba2bafa221e5d7b5e"},
+    {file = "importlib_metadata-4.8.3.tar.gz", hash = "sha256:766abffff765960fcc18003801f7044eb6755ffae4521c8e8ce8e83b9c9b0668"},
 ]
 importlib-resources = [
-    {file = "importlib_resources-3.3.0-py2.py3-none-any.whl", hash = "sha256:a3d34a8464ce1d5d7c92b0ea4e921e696d86f2aa212e684451cb1482c8d84ed5"},
-    {file = "importlib_resources-3.3.0.tar.gz", hash = "sha256:7b51f0106c8ec564b1bef3d9c588bc694ce2b92125bbb6278f4f2f5b54ec3592"},
+    {file = "importlib_resources-5.2.3-py3-none-any.whl", hash = "sha256:ae35ed1cfe8c0d6c1a53ecd168167f01fa93b893d51a62cdf23aea044c67211b"},
+    {file = "importlib_resources-5.2.3.tar.gz", hash = "sha256:203d70dda34cfbfbb42324a8d4211196e7d3e858de21a5eb68c6d1cdd99e4e98"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -587,224 +647,295 @@ mypy-extensions = [
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
 nodeenv = [
-    {file = "nodeenv-1.5.0-py2.py3-none-any.whl", hash = "sha256:5304d424c529c997bc888453aeaa6362d242b6b4631e90f3d4bf1b290f1c84a9"},
-    {file = "nodeenv-1.5.0.tar.gz", hash = "sha256:ab45090ae383b716c4ef89e690c41ff8c2b257b85b309f01f3654df3d084bd7c"},
+    {file = "nodeenv-1.6.0-py2.py3-none-any.whl", hash = "sha256:621e6b7076565ddcacd2db0294c0381e01fd28945ab36bcf00f41c5daf63bef7"},
+    {file = "nodeenv-1.6.0.tar.gz", hash = "sha256:3ef13ff90291ba2a4a7a4ff9a979b63ffdd00a464dbe04acf0ea6471517a4c2b"},
 ]
 numpy = [
-    {file = "numpy-1.19.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:e9b30d4bd69498fc0c3fe9db5f62fffbb06b8eb9321f92cc970f2969be5e3949"},
-    {file = "numpy-1.19.4-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:fedbd128668ead37f33917820b704784aff695e0019309ad446a6d0b065b57e4"},
-    {file = "numpy-1.19.4-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:8ece138c3a16db8c1ad38f52eb32be6086cc72f403150a79336eb2045723a1ad"},
-    {file = "numpy-1.19.4-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:64324f64f90a9e4ef732be0928be853eee378fd6a01be21a0a8469c4f2682c83"},
-    {file = "numpy-1.19.4-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:ad6f2ff5b1989a4899bf89800a671d71b1612e5ff40866d1f4d8bcf48d4e5764"},
-    {file = "numpy-1.19.4-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:d6c7bb82883680e168b55b49c70af29b84b84abb161cbac2800e8fcb6f2109b6"},
-    {file = "numpy-1.19.4-cp36-cp36m-win32.whl", hash = "sha256:13d166f77d6dc02c0a73c1101dd87fdf01339febec1030bd810dcd53fff3b0f1"},
-    {file = "numpy-1.19.4-cp36-cp36m-win_amd64.whl", hash = "sha256:448ebb1b3bf64c0267d6b09a7cba26b5ae61b6d2dbabff7c91b660c7eccf2bdb"},
-    {file = "numpy-1.19.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:27d3f3b9e3406579a8af3a9f262f5339005dd25e0ecf3cf1559ff8a49ed5cbf2"},
-    {file = "numpy-1.19.4-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:16c1b388cc31a9baa06d91a19366fb99ddbe1c7b205293ed072211ee5bac1ed2"},
-    {file = "numpy-1.19.4-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e5b6ed0f0b42317050c88022349d994fe72bfe35f5908617512cd8c8ef9da2a9"},
-    {file = "numpy-1.19.4-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:18bed2bcb39e3f758296584337966e68d2d5ba6aab7e038688ad53c8f889f757"},
-    {file = "numpy-1.19.4-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:fe45becb4c2f72a0907c1d0246ea6449fe7a9e2293bb0e11c4e9a32bb0930a15"},
-    {file = "numpy-1.19.4-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:6d7593a705d662be5bfe24111af14763016765f43cb6923ed86223f965f52387"},
-    {file = "numpy-1.19.4-cp37-cp37m-win32.whl", hash = "sha256:6ae6c680f3ebf1cf7ad1d7748868b39d9f900836df774c453c11c5440bc15b36"},
-    {file = "numpy-1.19.4-cp37-cp37m-win_amd64.whl", hash = "sha256:9eeb7d1d04b117ac0d38719915ae169aa6b61fca227b0b7d198d43728f0c879c"},
-    {file = "numpy-1.19.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:cb1017eec5257e9ac6209ac172058c430e834d5d2bc21961dceeb79d111e5909"},
-    {file = "numpy-1.19.4-cp38-cp38-manylinux1_i686.whl", hash = "sha256:edb01671b3caae1ca00881686003d16c2209e07b7ef8b7639f1867852b948f7c"},
-    {file = "numpy-1.19.4-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:f29454410db6ef8126c83bd3c968d143304633d45dc57b51252afbd79d700893"},
-    {file = "numpy-1.19.4-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:ec149b90019852266fec2341ce1db513b843e496d5a8e8cdb5ced1923a92faab"},
-    {file = "numpy-1.19.4-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:1aeef46a13e51931c0b1cf8ae1168b4a55ecd282e6688fdb0a948cc5a1d5afb9"},
-    {file = "numpy-1.19.4-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:08308c38e44cc926bdfce99498b21eec1f848d24c302519e64203a8da99a97db"},
-    {file = "numpy-1.19.4-cp38-cp38-win32.whl", hash = "sha256:5734bdc0342aba9dfc6f04920988140fb41234db42381cf7ccba64169f9fe7ac"},
-    {file = "numpy-1.19.4-cp38-cp38-win_amd64.whl", hash = "sha256:09c12096d843b90eafd01ea1b3307e78ddd47a55855ad402b157b6c4862197ce"},
-    {file = "numpy-1.19.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:e452dc66e08a4ce642a961f134814258a082832c78c90351b75c41ad16f79f63"},
-    {file = "numpy-1.19.4-cp39-cp39-manylinux1_i686.whl", hash = "sha256:a5d897c14513590a85774180be713f692df6fa8ecf6483e561a6d47309566f37"},
-    {file = "numpy-1.19.4-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:a09f98011236a419ee3f49cedc9ef27d7a1651df07810ae430a6b06576e0b414"},
-    {file = "numpy-1.19.4-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:50e86c076611212ca62e5a59f518edafe0c0730f7d9195fec718da1a5c2bb1fc"},
-    {file = "numpy-1.19.4-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:f0d3929fe88ee1c155129ecd82f981b8856c5d97bcb0d5f23e9b4242e79d1de3"},
-    {file = "numpy-1.19.4-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:c42c4b73121caf0ed6cd795512c9c09c52a7287b04d105d112068c1736d7c753"},
-    {file = "numpy-1.19.4-cp39-cp39-win32.whl", hash = "sha256:8cac8790a6b1ddf88640a9267ee67b1aee7a57dfa2d2dd33999d080bc8ee3a0f"},
-    {file = "numpy-1.19.4-cp39-cp39-win_amd64.whl", hash = "sha256:4377e10b874e653fe96985c05feed2225c912e328c8a26541f7fc600fb9c637b"},
-    {file = "numpy-1.19.4-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:2a2740aa9733d2e5b2dfb33639d98a64c3b0f24765fed86b0fd2aec07f6a0a08"},
-    {file = "numpy-1.19.4.zip", hash = "sha256:141ec3a3300ab89c7f2b0775289954d193cc8edb621ea05f99db9cb181530512"},
+    {file = "numpy-1.19.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:cc6bd4fd593cb261332568485e20a0712883cf631f6f5e8e86a52caa8b2b50ff"},
+    {file = "numpy-1.19.5-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:aeb9ed923be74e659984e321f609b9ba54a48354bfd168d21a2b072ed1e833ea"},
+    {file = "numpy-1.19.5-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:8b5e972b43c8fc27d56550b4120fe6257fdc15f9301914380b27f74856299fea"},
+    {file = "numpy-1.19.5-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:43d4c81d5ffdff6bae58d66a3cd7f54a7acd9a0e7b18d97abb255defc09e3140"},
+    {file = "numpy-1.19.5-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:a4646724fba402aa7504cd48b4b50e783296b5e10a524c7a6da62e4a8ac9698d"},
+    {file = "numpy-1.19.5-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:2e55195bc1c6b705bfd8ad6f288b38b11b1af32f3c8289d6c50d47f950c12e76"},
+    {file = "numpy-1.19.5-cp36-cp36m-win32.whl", hash = "sha256:39b70c19ec771805081578cc936bbe95336798b7edf4732ed102e7a43ec5c07a"},
+    {file = "numpy-1.19.5-cp36-cp36m-win_amd64.whl", hash = "sha256:dbd18bcf4889b720ba13a27ec2f2aac1981bd41203b3a3b27ba7a33f88ae4827"},
+    {file = "numpy-1.19.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:603aa0706be710eea8884af807b1b3bc9fb2e49b9f4da439e76000f3b3c6ff0f"},
+    {file = "numpy-1.19.5-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:cae865b1cae1ec2663d8ea56ef6ff185bad091a5e33ebbadd98de2cfa3fa668f"},
+    {file = "numpy-1.19.5-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:36674959eed6957e61f11c912f71e78857a8d0604171dfd9ce9ad5cbf41c511c"},
+    {file = "numpy-1.19.5-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:06fab248a088e439402141ea04f0fffb203723148f6ee791e9c75b3e9e82f080"},
+    {file = "numpy-1.19.5-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:6149a185cece5ee78d1d196938b2a8f9d09f5a5ebfbba66969302a778d5ddd1d"},
+    {file = "numpy-1.19.5-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:50a4a0ad0111cc1b71fa32dedd05fa239f7fb5a43a40663269bb5dc7877cfd28"},
+    {file = "numpy-1.19.5-cp37-cp37m-win32.whl", hash = "sha256:d051ec1c64b85ecc69531e1137bb9751c6830772ee5c1c426dbcfe98ef5788d7"},
+    {file = "numpy-1.19.5-cp37-cp37m-win_amd64.whl", hash = "sha256:a12ff4c8ddfee61f90a1633a4c4afd3f7bcb32b11c52026c92a12e1325922d0d"},
+    {file = "numpy-1.19.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:cf2402002d3d9f91c8b01e66fbb436a4ed01c6498fffed0e4c7566da1d40ee1e"},
+    {file = "numpy-1.19.5-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1ded4fce9cfaaf24e7a0ab51b7a87be9038ea1ace7f34b841fe3b6894c721d1c"},
+    {file = "numpy-1.19.5-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:012426a41bc9ab63bb158635aecccc7610e3eff5d31d1eb43bc099debc979d94"},
+    {file = "numpy-1.19.5-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:759e4095edc3c1b3ac031f34d9459fa781777a93ccc633a472a5468587a190ff"},
+    {file = "numpy-1.19.5-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:a9d17f2be3b427fbb2bce61e596cf555d6f8a56c222bd2ca148baeeb5e5c783c"},
+    {file = "numpy-1.19.5-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:99abf4f353c3d1a0c7a5f27699482c987cf663b1eac20db59b8c7b061eabd7fc"},
+    {file = "numpy-1.19.5-cp38-cp38-win32.whl", hash = "sha256:384ec0463d1c2671170901994aeb6dce126de0a95ccc3976c43b0038a37329c2"},
+    {file = "numpy-1.19.5-cp38-cp38-win_amd64.whl", hash = "sha256:811daee36a58dc79cf3d8bdd4a490e4277d0e4b7d103a001a4e73ddb48e7e6aa"},
+    {file = "numpy-1.19.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c843b3f50d1ab7361ca4f0b3639bf691569493a56808a0b0c54a051d260b7dbd"},
+    {file = "numpy-1.19.5-cp39-cp39-manylinux1_i686.whl", hash = "sha256:d6631f2e867676b13026e2846180e2c13c1e11289d67da08d71cacb2cd93d4aa"},
+    {file = "numpy-1.19.5-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:7fb43004bce0ca31d8f13a6eb5e943fa73371381e53f7074ed21a4cb786c32f8"},
+    {file = "numpy-1.19.5-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:2ea52bd92ab9f768cc64a4c3ef8f4b2580a17af0a5436f6126b08efbd1838371"},
+    {file = "numpy-1.19.5-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:400580cbd3cff6ffa6293df2278c75aef2d58d8d93d3c5614cd67981dae68ceb"},
+    {file = "numpy-1.19.5-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:df609c82f18c5b9f6cb97271f03315ff0dbe481a2a02e56aeb1b1a985ce38e60"},
+    {file = "numpy-1.19.5-cp39-cp39-win32.whl", hash = "sha256:ab83f24d5c52d60dbc8cd0528759532736b56db58adaa7b5f1f76ad551416a1e"},
+    {file = "numpy-1.19.5-cp39-cp39-win_amd64.whl", hash = "sha256:0eef32ca3132a48e43f6a0f5a82cb508f22ce5a3d6f67a8329c81c8e226d3f6e"},
+    {file = "numpy-1.19.5-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:a0d53e51a6cb6f0d9082decb7a4cb6dfb33055308c4c44f53103c073f649af73"},
+    {file = "numpy-1.19.5.zip", hash = "sha256:a76f502430dd98d7546e1ea2250a7360c065a5fdea52b2dffe8ae7180909b6f4"},
 ]
 packaging = [
-    {file = "packaging-20.4-py2.py3-none-any.whl", hash = "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"},
-    {file = "packaging-20.4.tar.gz", hash = "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8"},
+    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
+    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
 ]
 pandas = [
-    {file = "pandas-1.1.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:e2b8557fe6d0a18db4d61c028c6af61bfed44ef90e419ed6fadbdc079eba141e"},
-    {file = "pandas-1.1.4-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:3aa8e10768c730cc1b610aca688f588831fa70b65a26cb549fbb9f35049a05e0"},
-    {file = "pandas-1.1.4-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:185cf8c8f38b169dbf7001e1a88c511f653fbb9dfa3e048f5e19c38049e991dc"},
-    {file = "pandas-1.1.4-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:0d9a38a59242a2f6298fff45d09768b78b6eb0c52af5919ea9e45965d7ba56d9"},
-    {file = "pandas-1.1.4-cp36-cp36m-win32.whl", hash = "sha256:8b4c2055ebd6e497e5ecc06efa5b8aa76f59d15233356eb10dad22a03b757805"},
-    {file = "pandas-1.1.4-cp36-cp36m-win_amd64.whl", hash = "sha256:5dac3aeaac5feb1016e94bde851eb2012d1733a222b8afa788202b836c97dad5"},
-    {file = "pandas-1.1.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:6d2b5b58e7df46b2c010ec78d7fb9ab20abf1d306d0614d3432e7478993fbdb0"},
-    {file = "pandas-1.1.4-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:c681e8fcc47a767bf868341d8f0d76923733cbdcabd6ec3a3560695c69f14a1e"},
-    {file = "pandas-1.1.4-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:c5a3597880a7a29a31ebd39b73b2c824316ae63a05c3c8a5ce2aea3fc68afe35"},
-    {file = "pandas-1.1.4-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:6613c7815ee0b20222178ad32ec144061cb07e6a746970c9160af1ebe3ad43b4"},
-    {file = "pandas-1.1.4-cp37-cp37m-win32.whl", hash = "sha256:43cea38cbcadb900829858884f49745eb1f42f92609d368cabcc674b03e90efc"},
-    {file = "pandas-1.1.4-cp37-cp37m-win_amd64.whl", hash = "sha256:5378f58172bd63d8c16dd5d008d7dcdd55bf803fcdbe7da2dcb65dbbf322f05b"},
-    {file = "pandas-1.1.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:a7d2547b601ecc9a53fd41561de49a43d2231728ad65c7713d6b616cd02ddbed"},
-    {file = "pandas-1.1.4-cp38-cp38-manylinux1_i686.whl", hash = "sha256:41746d520f2b50409dffdba29a15c42caa7babae15616bcf80800d8cfcae3d3e"},
-    {file = "pandas-1.1.4-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:a15653480e5b92ee376f8458197a58cca89a6e95d12cccb4c2d933df5cecc63f"},
-    {file = "pandas-1.1.4-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:5fdb2a61e477ce58d3f1fdf2470ee142d9f0dde4969032edaf0b8f1a9dafeaa2"},
-    {file = "pandas-1.1.4-cp38-cp38-win32.whl", hash = "sha256:8a5d7e57b9df2c0a9a202840b2881bb1f7a648eba12dd2d919ac07a33a36a97f"},
-    {file = "pandas-1.1.4-cp38-cp38-win_amd64.whl", hash = "sha256:54404abb1cd3f89d01f1fb5350607815326790efb4789be60508f458cdd5ccbf"},
-    {file = "pandas-1.1.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:112c5ba0f9ea0f60b2cc38c25f87ca1d5ca10f71efbee8e0f1bee9cf584ed5d5"},
-    {file = "pandas-1.1.4-cp39-cp39-manylinux1_i686.whl", hash = "sha256:cf135a08f306ebbcfea6da8bf775217613917be23e5074c69215b91e180caab4"},
-    {file = "pandas-1.1.4-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:b1f8111635700de7ac350b639e7e452b06fc541a328cf6193cf8fc638804bab8"},
-    {file = "pandas-1.1.4-cp39-cp39-win32.whl", hash = "sha256:09e0503758ad61afe81c9069505f8cb8c1e36ea8cc1e6826a95823ef5b327daf"},
-    {file = "pandas-1.1.4-cp39-cp39-win_amd64.whl", hash = "sha256:0a11a6290ef3667575cbd4785a1b62d658c25a2fd70a5adedba32e156a8f1773"},
-    {file = "pandas-1.1.4.tar.gz", hash = "sha256:a979d0404b135c63954dea79e6246c45dd45371a88631cdbb4877d844e6de3b6"},
+    {file = "pandas-1.1.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:bf23a3b54d128b50f4f9d4675b3c1857a688cc6731a32f931837d72effb2698d"},
+    {file = "pandas-1.1.5-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:5a780260afc88268a9d3ac3511d8f494fdcf637eece62fb9eb656a63d53eb7ca"},
+    {file = "pandas-1.1.5-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:b61080750d19a0122469ab59b087380721d6b72a4e7d962e4d7e63e0c4504814"},
+    {file = "pandas-1.1.5-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:0de3ddb414d30798cbf56e642d82cac30a80223ad6fe484d66c0ce01a84d6f2f"},
+    {file = "pandas-1.1.5-cp36-cp36m-win32.whl", hash = "sha256:70865f96bb38fec46f7ebd66d4b5cfd0aa6b842073f298d621385ae3898d28b5"},
+    {file = "pandas-1.1.5-cp36-cp36m-win_amd64.whl", hash = "sha256:19a2148a1d02791352e9fa637899a78e371a3516ac6da5c4edc718f60cbae648"},
+    {file = "pandas-1.1.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:26fa92d3ac743a149a31b21d6f4337b0594b6302ea5575b37af9ca9611e8981a"},
+    {file = "pandas-1.1.5-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:c16d59c15d946111d2716856dd5479221c9e4f2f5c7bc2d617f39d870031e086"},
+    {file = "pandas-1.1.5-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:3be7a7a0ca71a2640e81d9276f526bca63505850add10206d0da2e8a0a325dae"},
+    {file = "pandas-1.1.5-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:573fba5b05bf2c69271a32e52399c8de599e4a15ab7cec47d3b9c904125ab788"},
+    {file = "pandas-1.1.5-cp37-cp37m-win32.whl", hash = "sha256:21b5a2b033380adbdd36b3116faaf9a4663e375325831dac1b519a44f9e439bb"},
+    {file = "pandas-1.1.5-cp37-cp37m-win_amd64.whl", hash = "sha256:24c7f8d4aee71bfa6401faeba367dd654f696a77151a8a28bc2013f7ced4af98"},
+    {file = "pandas-1.1.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2860a97cbb25444ffc0088b457da0a79dc79f9c601238a3e0644312fcc14bf11"},
+    {file = "pandas-1.1.5-cp38-cp38-manylinux1_i686.whl", hash = "sha256:5008374ebb990dad9ed48b0f5d0038124c73748f5384cc8c46904dace27082d9"},
+    {file = "pandas-1.1.5-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:2c2f7c670ea4e60318e4b7e474d56447cf0c7d83b3c2a5405a0dbb2600b9c48e"},
+    {file = "pandas-1.1.5-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:0a643bae4283a37732ddfcecab3f62dd082996021b980f580903f4e8e01b3c5b"},
+    {file = "pandas-1.1.5-cp38-cp38-win32.whl", hash = "sha256:5447ea7af4005b0daf695a316a423b96374c9c73ffbd4533209c5ddc369e644b"},
+    {file = "pandas-1.1.5-cp38-cp38-win_amd64.whl", hash = "sha256:4c62e94d5d49db116bef1bd5c2486723a292d79409fc9abd51adf9e05329101d"},
+    {file = "pandas-1.1.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:731568be71fba1e13cae212c362f3d2ca8932e83cb1b85e3f1b4dd77d019254a"},
+    {file = "pandas-1.1.5-cp39-cp39-manylinux1_i686.whl", hash = "sha256:c61c043aafb69329d0f961b19faa30b1dab709dd34c9388143fc55680059e55a"},
+    {file = "pandas-1.1.5-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:2b1c6cd28a0dfda75c7b5957363333f01d370936e4c6276b7b8e696dd500582a"},
+    {file = "pandas-1.1.5-cp39-cp39-win32.whl", hash = "sha256:c94ff2780a1fd89f190390130d6d36173ca59fcfb3fe0ff596f9a56518191ccb"},
+    {file = "pandas-1.1.5-cp39-cp39-win_amd64.whl", hash = "sha256:edda9bacc3843dfbeebaf7a701763e68e741b08fccb889c003b0a52f0ee95782"},
+    {file = "pandas-1.1.5.tar.gz", hash = "sha256:f10fc41ee3c75a474d3bdf68d396f10782d013d7f67db99c0efbfd0acb99701b"},
 ]
 pathspec = [
-    {file = "pathspec-0.8.1-py2.py3-none-any.whl", hash = "sha256:aa0cb481c4041bf52ffa7b0d8fa6cd3e88a2ca4879c533c9153882ee2556790d"},
-    {file = "pathspec-0.8.1.tar.gz", hash = "sha256:86379d6b86d75816baba717e64b1a3a3469deb93bb76d613c9ce79edc5cb68fd"},
+    {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
+    {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
+]
+pint = [
+    {file = "Pint-0.14-py2.py3-none-any.whl", hash = "sha256:62a5cdecd7cadb02c733eb18a34e7b9f3efe92ee9b0b752067b42b84277af874"},
+    {file = "Pint-0.14.tar.gz", hash = "sha256:9aa450ebb9d722ed03fa9a450104cfd16c479b49f862d547c6f77320de597f72"},
+]
+platformdirs = [
+    {file = "platformdirs-2.4.0-py3-none-any.whl", hash = "sha256:8868bbe3c3c80d42f20156f22e7131d2fb321f5bc86a2a345375c6481a67021d"},
+    {file = "platformdirs-2.4.0.tar.gz", hash = "sha256:367a5e80b3d04d2428ffa76d33f124cf11e8fff2acdaa9b43d545f5c7d661ef2"},
 ]
 pluggy = [
-    {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
-    {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
+    {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
+    {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
 ]
 pprint-ordered-sets = [
     {file = "pprint_ordered_sets-1.0.0-py3-none-any.whl", hash = "sha256:4b4428fe51020e932ec5d8feed42cf8dd1dbcd85f1c99a9709010314ad9bd4e8"},
     {file = "pprint_ordered_sets-1.0.0.tar.gz", hash = "sha256:742bf4f5912123f970d98bbca17379b1e610d9d025adbaadb3b37e439b50c174"},
 ]
 pre-commit = [
-    {file = "pre_commit-2.9.0-py2.py3-none-any.whl", hash = "sha256:4aee0db4808fa48d2458cedd5b9a084ef24dda1a0fa504432a11977a4d1cfd0a"},
-    {file = "pre_commit-2.9.0.tar.gz", hash = "sha256:b2d106d51c6ba6217e859d81774aae33fd825fe7de0dcf0c46e2586333d7a92e"},
+    {file = "pre_commit-2.17.0-py2.py3-none-any.whl", hash = "sha256:725fa7459782d7bec5ead072810e47351de01709be838c2ce1726b9591dad616"},
+    {file = "pre_commit-2.17.0.tar.gz", hash = "sha256:c1a8040ff15ad3d648c70cc3e55b93e4d2d5b687320955505587fd79bbaed06a"},
 ]
 py = [
-    {file = "py-1.9.0-py2.py3-none-any.whl", hash = "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2"},
-    {file = "py-1.9.0.tar.gz", hash = "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"},
+    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
+    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
 ]
 pycodestyle = [
-    {file = "pycodestyle-2.6.0-py2.py3-none-any.whl", hash = "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367"},
-    {file = "pycodestyle-2.6.0.tar.gz", hash = "sha256:c58a7d2815e0e8d7972bf1803331fb0152f867bd89adf8a01dfd55085434192e"},
+    {file = "pycodestyle-2.7.0-py2.py3-none-any.whl", hash = "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068"},
+    {file = "pycodestyle-2.7.0.tar.gz", hash = "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"},
 ]
 pyflakes = [
-    {file = "pyflakes-2.2.0-py2.py3-none-any.whl", hash = "sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92"},
-    {file = "pyflakes-2.2.0.tar.gz", hash = "sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8"},
+    {file = "pyflakes-2.3.1-py2.py3-none-any.whl", hash = "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3"},
+    {file = "pyflakes-2.3.1.tar.gz", hash = "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"},
 ]
 pyparsing = [
-    {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
-    {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
+    {file = "pyparsing-3.0.7-py3-none-any.whl", hash = "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"},
+    {file = "pyparsing-3.0.7.tar.gz", hash = "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea"},
 ]
 pytest = [
-    {file = "pytest-6.1.2-py3-none-any.whl", hash = "sha256:4288fed0d9153d9646bfcdf0c0428197dba1ecb27a33bb6e031d002fa88653fe"},
-    {file = "pytest-6.1.2.tar.gz", hash = "sha256:c0a7e94a8cdbc5422a51ccdad8e6f1024795939cc89159a0ae7f0b316ad3823e"},
+    {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},
+    {file = "pytest-6.2.5.tar.gz", hash = "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89"},
 ]
 pytest-mock = [
-    {file = "pytest-mock-3.3.1.tar.gz", hash = "sha256:a4d6d37329e4a893e77d9ffa89e838dd2b45d5dc099984cf03c703ac8411bb82"},
-    {file = "pytest_mock-3.3.1-py3-none-any.whl", hash = "sha256:024e405ad382646318c4281948aadf6fe1135632bea9cc67366ea0c4098ef5f2"},
+    {file = "pytest-mock-3.6.1.tar.gz", hash = "sha256:40217a058c52a63f1042f0784f62009e976ba824c418cced42e88d5f40ab0e62"},
+    {file = "pytest_mock-3.6.1-py3-none-any.whl", hash = "sha256:30c2f2cc9759e76eee674b81ea28c9f0b94f8f0445a1b87762cadf774f0df7e3"},
 ]
 python-dateutil = [
-    {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},
-    {file = "python_dateutil-2.8.1-py2.py3-none-any.whl", hash = "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"},
+    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
+    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
 ]
 pytz = [
-    {file = "pytz-2020.4-py2.py3-none-any.whl", hash = "sha256:5c55e189b682d420be27c6995ba6edce0c0a77dd67bfbe2ae6607134d5851ffd"},
-    {file = "pytz-2020.4.tar.gz", hash = "sha256:3e6b7dd2d1e0a59084bcee14a17af60c5c562cdc16d828e8eba2e683d3a7e268"},
+    {file = "pytz-2022.1-py2.py3-none-any.whl", hash = "sha256:e68985985296d9a66a881eb3193b0906246245294a881e7c8afe623866ac6a5c"},
+    {file = "pytz-2022.1.tar.gz", hash = "sha256:1e760e2fe6a8163bc0b3d9a19c4f84342afa0a2affebfaa84b01b978a02ecaa7"},
 ]
 pyyaml = [
-    {file = "PyYAML-5.3.1-cp27-cp27m-win32.whl", hash = "sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f"},
-    {file = "PyYAML-5.3.1-cp27-cp27m-win_amd64.whl", hash = "sha256:240097ff019d7c70a4922b6869d8a86407758333f02203e0fc6ff79c5dcede76"},
-    {file = "PyYAML-5.3.1-cp35-cp35m-win32.whl", hash = "sha256:4f4b913ca1a7319b33cfb1369e91e50354d6f07a135f3b901aca02aa95940bd2"},
-    {file = "PyYAML-5.3.1-cp35-cp35m-win_amd64.whl", hash = "sha256:cc8955cfbfc7a115fa81d85284ee61147059a753344bc51098f3ccd69b0d7e0c"},
-    {file = "PyYAML-5.3.1-cp36-cp36m-win32.whl", hash = "sha256:7739fc0fa8205b3ee8808aea45e968bc90082c10aef6ea95e855e10abf4a37b2"},
-    {file = "PyYAML-5.3.1-cp36-cp36m-win_amd64.whl", hash = "sha256:69f00dca373f240f842b2931fb2c7e14ddbacd1397d57157a9b005a6a9942648"},
-    {file = "PyYAML-5.3.1-cp37-cp37m-win32.whl", hash = "sha256:d13155f591e6fcc1ec3b30685d50bf0711574e2c0dfffd7644babf8b5102ca1a"},
-    {file = "PyYAML-5.3.1-cp37-cp37m-win_amd64.whl", hash = "sha256:73f099454b799e05e5ab51423c7bcf361c58d3206fa7b0d555426b1f4d9a3eaf"},
-    {file = "PyYAML-5.3.1-cp38-cp38-win32.whl", hash = "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97"},
-    {file = "PyYAML-5.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee"},
-    {file = "PyYAML-5.3.1.tar.gz", hash = "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d"},
+    {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
+    {file = "PyYAML-6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a80a78046a72361de73f8f395f1f1e49f956c6be882eed58505a15f3e430962b"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
+    {file = "PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
+    {file = "PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
+    {file = "PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98c4d36e99714e55cfbaaee6dd5badbc9a1ec339ebfc3b1f52e293aee6bb71a4"},
+    {file = "PyYAML-6.0-cp36-cp36m-win32.whl", hash = "sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293"},
+    {file = "PyYAML-6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:07751360502caac1c067a8132d150cf3d61339af5691fe9e87803040dbc5db57"},
+    {file = "PyYAML-6.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:819b3830a1543db06c4d4b865e70ded25be52a2e0631ccd2f6a47a2822f2fd7c"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:473f9edb243cb1935ab5a084eb238d842fb8f404ed2193a915d1784b5a6b5fc0"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ce82d761c532fe4ec3f87fc45688bdd3a4c1dc5e0b4a19814b9009a29baefd4"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:231710d57adfd809ef5d34183b8ed1eeae3f76459c18fb4a0b373ad56bedcdd9"},
+    {file = "PyYAML-6.0-cp37-cp37m-win32.whl", hash = "sha256:c5687b8d43cf58545ade1fe3e055f70eac7a5a1a0bf42824308d868289a95737"},
+    {file = "PyYAML-6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:d15a181d1ecd0d4270dc32edb46f7cb7733c7c508857278d3d378d14d606db2d"},
+    {file = "PyYAML-6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0b4624f379dab24d3725ffde76559cff63d9ec94e1736b556dacdfebe5ab6d4b"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:213c60cd50106436cc818accf5baa1aba61c0189ff610f64f4a3e8c6726218ba"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9fa600030013c4de8165339db93d182b9431076eb98eb40ee068700c9c813e34"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:277a0ef2981ca40581a47093e9e2d13b3f1fbbeffae064c1d21bfceba2030287"},
+    {file = "PyYAML-6.0-cp38-cp38-win32.whl", hash = "sha256:d4eccecf9adf6fbcc6861a38015c2a64f38b9d94838ac1810a9023a0609e1b78"},
+    {file = "PyYAML-6.0-cp38-cp38-win_amd64.whl", hash = "sha256:1e4747bc279b4f613a09eb64bba2ba602d8a6664c6ce6396a4d0cd413a50ce07"},
+    {file = "PyYAML-6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b"},
+    {file = "PyYAML-6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d67d839ede4ed1b28a4e8909735fc992a923cdb84e618544973d7dfc71540803"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cba8c411ef271aa037d7357a2bc8f9ee8b58b9965831d9e51baf703280dc73d3"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:40527857252b61eacd1d9af500c3337ba8deb8fc298940291486c465c8b46ec0"},
+    {file = "PyYAML-6.0-cp39-cp39-win32.whl", hash = "sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb"},
+    {file = "PyYAML-6.0-cp39-cp39-win_amd64.whl", hash = "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c"},
+    {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
 ]
 regex = [
-    {file = "regex-2020.11.13-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:8b882a78c320478b12ff024e81dc7d43c1462aa4a3341c754ee65d857a521f85"},
-    {file = "regex-2020.11.13-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:a63f1a07932c9686d2d416fb295ec2c01ab246e89b4d58e5fa468089cab44b70"},
-    {file = "regex-2020.11.13-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:6e4b08c6f8daca7d8f07c8d24e4331ae7953333dbd09c648ed6ebd24db5a10ee"},
-    {file = "regex-2020.11.13-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:bba349276b126947b014e50ab3316c027cac1495992f10e5682dc677b3dfa0c5"},
-    {file = "regex-2020.11.13-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:56e01daca75eae420bce184edd8bb341c8eebb19dd3bce7266332258f9fb9dd7"},
-    {file = "regex-2020.11.13-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:6a8ce43923c518c24a2579fda49f093f1397dad5d18346211e46f134fc624e31"},
-    {file = "regex-2020.11.13-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:1ab79fcb02b930de09c76d024d279686ec5d532eb814fd0ed1e0051eb8bd2daa"},
-    {file = "regex-2020.11.13-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:9801c4c1d9ae6a70aeb2128e5b4b68c45d4f0af0d1535500884d644fa9b768c6"},
-    {file = "regex-2020.11.13-cp36-cp36m-win32.whl", hash = "sha256:49cae022fa13f09be91b2c880e58e14b6da5d10639ed45ca69b85faf039f7a4e"},
-    {file = "regex-2020.11.13-cp36-cp36m-win_amd64.whl", hash = "sha256:749078d1eb89484db5f34b4012092ad14b327944ee7f1c4f74d6279a6e4d1884"},
-    {file = "regex-2020.11.13-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b2f4007bff007c96a173e24dcda236e5e83bde4358a557f9ccf5e014439eae4b"},
-    {file = "regex-2020.11.13-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:38c8fd190db64f513fe4e1baa59fed086ae71fa45083b6936b52d34df8f86a88"},
-    {file = "regex-2020.11.13-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:5862975b45d451b6db51c2e654990c1820523a5b07100fc6903e9c86575202a0"},
-    {file = "regex-2020.11.13-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:262c6825b309e6485ec2493ffc7e62a13cf13fb2a8b6d212f72bd53ad34118f1"},
-    {file = "regex-2020.11.13-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:bafb01b4688833e099d79e7efd23f99172f501a15c44f21ea2118681473fdba0"},
-    {file = "regex-2020.11.13-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:e32f5f3d1b1c663af7f9c4c1e72e6ffe9a78c03a31e149259f531e0fed826512"},
-    {file = "regex-2020.11.13-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:3bddc701bdd1efa0d5264d2649588cbfda549b2899dc8d50417e47a82e1387ba"},
-    {file = "regex-2020.11.13-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:02951b7dacb123d8ea6da44fe45ddd084aa6777d4b2454fa0da61d569c6fa538"},
-    {file = "regex-2020.11.13-cp37-cp37m-win32.whl", hash = "sha256:0d08e71e70c0237883d0bef12cad5145b84c3705e9c6a588b2a9c7080e5af2a4"},
-    {file = "regex-2020.11.13-cp37-cp37m-win_amd64.whl", hash = "sha256:1fa7ee9c2a0e30405e21031d07d7ba8617bc590d391adfc2b7f1e8b99f46f444"},
-    {file = "regex-2020.11.13-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:baf378ba6151f6e272824b86a774326f692bc2ef4cc5ce8d5bc76e38c813a55f"},
-    {file = "regex-2020.11.13-cp38-cp38-manylinux1_i686.whl", hash = "sha256:e3faaf10a0d1e8e23a9b51d1900b72e1635c2d5b0e1bea1c18022486a8e2e52d"},
-    {file = "regex-2020.11.13-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:2a11a3e90bd9901d70a5b31d7dd85114755a581a5da3fc996abfefa48aee78af"},
-    {file = "regex-2020.11.13-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:d1ebb090a426db66dd80df8ca85adc4abfcbad8a7c2e9a5ec7513ede522e0a8f"},
-    {file = "regex-2020.11.13-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:b2b1a5ddae3677d89b686e5c625fc5547c6e492bd755b520de5332773a8af06b"},
-    {file = "regex-2020.11.13-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:2c99e97d388cd0a8d30f7c514d67887d8021541b875baf09791a3baad48bb4f8"},
-    {file = "regex-2020.11.13-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:c084582d4215593f2f1d28b65d2a2f3aceff8342aa85afd7be23a9cad74a0de5"},
-    {file = "regex-2020.11.13-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:a3d748383762e56337c39ab35c6ed4deb88df5326f97a38946ddd19028ecce6b"},
-    {file = "regex-2020.11.13-cp38-cp38-win32.whl", hash = "sha256:7913bd25f4ab274ba37bc97ad0e21c31004224ccb02765ad984eef43e04acc6c"},
-    {file = "regex-2020.11.13-cp38-cp38-win_amd64.whl", hash = "sha256:6c54ce4b5d61a7129bad5c5dc279e222afd00e721bf92f9ef09e4fae28755683"},
-    {file = "regex-2020.11.13-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1862a9d9194fae76a7aaf0150d5f2a8ec1da89e8b55890b1786b8f88a0f619dc"},
-    {file = "regex-2020.11.13-cp39-cp39-manylinux1_i686.whl", hash = "sha256:4902e6aa086cbb224241adbc2f06235927d5cdacffb2425c73e6570e8d862364"},
-    {file = "regex-2020.11.13-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:7a25fcbeae08f96a754b45bdc050e1fb94b95cab046bf56b016c25e9ab127b3e"},
-    {file = "regex-2020.11.13-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:d2d8ce12b7c12c87e41123997ebaf1a5767a5be3ec545f64675388970f415e2e"},
-    {file = "regex-2020.11.13-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:f7d29a6fc4760300f86ae329e3b6ca28ea9c20823df123a2ea8693e967b29917"},
-    {file = "regex-2020.11.13-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:717881211f46de3ab130b58ec0908267961fadc06e44f974466d1887f865bd5b"},
-    {file = "regex-2020.11.13-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:3128e30d83f2e70b0bed9b2a34e92707d0877e460b402faca908c6667092ada9"},
-    {file = "regex-2020.11.13-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:8f6a2229e8ad946e36815f2a03386bb8353d4bde368fdf8ca5f0cb97264d3b5c"},
-    {file = "regex-2020.11.13-cp39-cp39-win32.whl", hash = "sha256:f8f295db00ef5f8bae530fc39af0b40486ca6068733fb860b42115052206466f"},
-    {file = "regex-2020.11.13-cp39-cp39-win_amd64.whl", hash = "sha256:a15f64ae3a027b64496a71ab1f722355e570c3fac5ba2801cafce846bf5af01d"},
-    {file = "regex-2020.11.13.tar.gz", hash = "sha256:83d6b356e116ca119db8e7c6fc2983289d87b27b3fac238cfe5dca529d884562"},
+    {file = "regex-2022.3.15-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:42eb13b93765c6698a5ab3bcd318d8c39bb42e5fa8a7fcf7d8d98923f3babdb1"},
+    {file = "regex-2022.3.15-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9beb03ff6fe509d6455971c2489dceb31687b38781206bcec8e68bdfcf5f1db2"},
+    {file = "regex-2022.3.15-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d0a5a1fdc9f148a8827d55b05425801acebeeefc9e86065c7ac8b8cc740a91ff"},
+    {file = "regex-2022.3.15-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cb374a2a4dba7c4be0b19dc7b1adc50e6c2c26c3369ac629f50f3c198f3743a4"},
+    {file = "regex-2022.3.15-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c33ce0c665dd325200209340a88438ba7a470bd5f09f7424e520e1a3ff835b52"},
+    {file = "regex-2022.3.15-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:04c09b9651fa814eeeb38e029dc1ae83149203e4eeb94e52bb868fadf64852bc"},
+    {file = "regex-2022.3.15-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ab5d89cfaf71807da93c131bb7a19c3e19eaefd613d14f3bce4e97de830b15df"},
+    {file = "regex-2022.3.15-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0e2630ae470d6a9f8e4967388c1eda4762706f5750ecf387785e0df63a4cc5af"},
+    {file = "regex-2022.3.15-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:df037c01d68d1958dad3463e2881d3638a0d6693483f58ad41001aa53a83fcea"},
+    {file = "regex-2022.3.15-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:940570c1a305bac10e8b2bc934b85a7709c649317dd16520471e85660275083a"},
+    {file = "regex-2022.3.15-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:7f63877c87552992894ea1444378b9c3a1d80819880ae226bb30b04789c0828c"},
+    {file = "regex-2022.3.15-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:3e265b388cc80c7c9c01bb4f26c9e536c40b2c05b7231fbb347381a2e1c8bf43"},
+    {file = "regex-2022.3.15-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:058054c7a54428d5c3e3739ac1e363dc9347d15e64833817797dc4f01fb94bb8"},
+    {file = "regex-2022.3.15-cp310-cp310-win32.whl", hash = "sha256:76435a92e444e5b8f346aed76801db1c1e5176c4c7e17daba074fbb46cb8d783"},
+    {file = "regex-2022.3.15-cp310-cp310-win_amd64.whl", hash = "sha256:174d964bc683b1e8b0970e1325f75e6242786a92a22cedb2a6ec3e4ae25358bd"},
+    {file = "regex-2022.3.15-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:6e1d8ed9e61f37881c8db383a124829a6e8114a69bd3377a25aecaeb9b3538f8"},
+    {file = "regex-2022.3.15-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b52771f05cff7517f7067fef19ffe545b1f05959e440d42247a17cd9bddae11b"},
+    {file = "regex-2022.3.15-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:673f5a393d603c34477dbad70db30025ccd23996a2d0916e942aac91cc42b31a"},
+    {file = "regex-2022.3.15-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8923e1c5231549fee78ff9b2914fad25f2e3517572bb34bfaa3aea682a758683"},
+    {file = "regex-2022.3.15-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:764e66a0e382829f6ad3bbce0987153080a511c19eb3d2f8ead3f766d14433ac"},
+    {file = "regex-2022.3.15-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cd00859291658fe1fda48a99559fb34da891c50385b0bfb35b808f98956ef1e7"},
+    {file = "regex-2022.3.15-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:aa2ce79f3889720b46e0aaba338148a1069aea55fda2c29e0626b4db20d9fcb7"},
+    {file = "regex-2022.3.15-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:34bb30c095342797608727baf5c8aa122406aa5edfa12107b8e08eb432d4c5d7"},
+    {file = "regex-2022.3.15-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:25ecb1dffc5e409ca42f01a2b2437f93024ff1612c1e7983bad9ee191a5e8828"},
+    {file = "regex-2022.3.15-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:aa5eedfc2461c16a092a2fabc5895f159915f25731740c9152a1b00f4bcf629a"},
+    {file = "regex-2022.3.15-cp36-cp36m-musllinux_1_1_s390x.whl", hash = "sha256:7d1a6e403ac8f1d91d8f51c441c3f99367488ed822bda2b40836690d5d0059f5"},
+    {file = "regex-2022.3.15-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:3e4d710ff6539026e49f15a3797c6b1053573c2b65210373ef0eec24480b900b"},
+    {file = "regex-2022.3.15-cp36-cp36m-win32.whl", hash = "sha256:0100f0ded953b6b17f18207907159ba9be3159649ad2d9b15535a74de70359d3"},
+    {file = "regex-2022.3.15-cp36-cp36m-win_amd64.whl", hash = "sha256:f320c070dea3f20c11213e56dbbd7294c05743417cde01392148964b7bc2d31a"},
+    {file = "regex-2022.3.15-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fc8c7958d14e8270171b3d72792b609c057ec0fa17d507729835b5cff6b7f69a"},
+    {file = "regex-2022.3.15-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ca6dcd17f537e9f3793cdde20ac6076af51b2bd8ad5fe69fa54373b17b48d3c"},
+    {file = "regex-2022.3.15-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0214ff6dff1b5a4b4740cfe6e47f2c4c92ba2938fca7abbea1359036305c132f"},
+    {file = "regex-2022.3.15-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a98ae493e4e80b3ded6503ff087a8492db058e9c68de371ac3df78e88360b374"},
+    {file = "regex-2022.3.15-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8b1cc70e31aacc152a12b39245974c8fccf313187eead559ee5966d50e1b5817"},
+    {file = "regex-2022.3.15-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b4829db3737480a9d5bfb1c0320c4ee13736f555f53a056aacc874f140e98f64"},
+    {file = "regex-2022.3.15-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:303b15a3d32bf5fe5a73288c316bac5807587f193ceee4eb6d96ee38663789fa"},
+    {file = "regex-2022.3.15-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:dc7b7c16a519d924c50876fb152af661a20749dcbf653c8759e715c1a7a95b18"},
+    {file = "regex-2022.3.15-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:ce3057777a14a9a1399b81eca6a6bfc9612047811234398b84c54aeff6d536ea"},
+    {file = "regex-2022.3.15-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:48081b6bff550fe10bcc20c01cf6c83dbca2ccf74eeacbfac240264775fd7ecf"},
+    {file = "regex-2022.3.15-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:dcbb7665a9db9f8d7642171152c45da60e16c4f706191d66a1dc47ec9f820aed"},
+    {file = "regex-2022.3.15-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:c155a1a80c5e7a8fa1d9bb1bf3c8a953532b53ab1196092749bafb9d3a7cbb60"},
+    {file = "regex-2022.3.15-cp37-cp37m-win32.whl", hash = "sha256:04b5ee2b6d29b4a99d38a6469aa1db65bb79d283186e8460542c517da195a8f6"},
+    {file = "regex-2022.3.15-cp37-cp37m-win_amd64.whl", hash = "sha256:797437e6024dc1589163675ae82f303103063a0a580c6fd8d0b9a0a6708da29e"},
+    {file = "regex-2022.3.15-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8afcd1c2297bc989dceaa0379ba15a6df16da69493635e53431d2d0c30356086"},
+    {file = "regex-2022.3.15-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:0066a6631c92774391f2ea0f90268f0d82fffe39cb946f0f9c6b382a1c61a5e5"},
+    {file = "regex-2022.3.15-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b8248f19a878c72d8c0a785a2cd45d69432e443c9f10ab924c29adda77b324ae"},
+    {file = "regex-2022.3.15-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8d1f3ea0d1924feb4cf6afb2699259f658a08ac6f8f3a4a806661c2dfcd66db1"},
+    {file = "regex-2022.3.15-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:794a6bc66c43db8ed06698fc32aaeaac5c4812d9f825e9589e56f311da7becd9"},
+    {file = "regex-2022.3.15-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4d1445824944e642ffa54c4f512da17a953699c563a356d8b8cbdad26d3b7598"},
+    {file = "regex-2022.3.15-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f553a1190ae6cd26e553a79f6b6cfba7b8f304da2071052fa33469da075ea625"},
+    {file = "regex-2022.3.15-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:75a5e6ce18982f0713c4bac0704bf3f65eed9b277edd3fb9d2b0ff1815943327"},
+    {file = "regex-2022.3.15-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:f16cf7e4e1bf88fecf7f41da4061f181a6170e179d956420f84e700fb8a3fd6b"},
+    {file = "regex-2022.3.15-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:dad3991f0678facca1a0831ec1ddece2eb4d1dd0f5150acb9440f73a3b863907"},
+    {file = "regex-2022.3.15-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:491fc754428514750ab21c2d294486223ce7385446f2c2f5df87ddbed32979ae"},
+    {file = "regex-2022.3.15-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:6504c22c173bb74075d7479852356bb7ca80e28c8e548d4d630a104f231e04fb"},
+    {file = "regex-2022.3.15-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:01c913cf573d1da0b34c9001a94977273b5ee2fe4cb222a5d5b320f3a9d1a835"},
+    {file = "regex-2022.3.15-cp38-cp38-win32.whl", hash = "sha256:029e9e7e0d4d7c3446aa92474cbb07dafb0b2ef1d5ca8365f059998c010600e6"},
+    {file = "regex-2022.3.15-cp38-cp38-win_amd64.whl", hash = "sha256:947a8525c0a95ba8dc873191f9017d1b1e3024d4dc757f694e0af3026e34044a"},
+    {file = "regex-2022.3.15-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:591d4fba554f24bfa0421ba040cd199210a24301f923ed4b628e1e15a1001ff4"},
+    {file = "regex-2022.3.15-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b9809404528a999cf02a400ee5677c81959bc5cb938fdc696b62eb40214e3632"},
+    {file = "regex-2022.3.15-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f08a7e4d62ea2a45557f561eea87c907222575ca2134180b6974f8ac81e24f06"},
+    {file = "regex-2022.3.15-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5a86cac984da35377ca9ac5e2e0589bd11b3aebb61801204bd99c41fac516f0d"},
+    {file = "regex-2022.3.15-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:286908cbe86b1a0240a867aecfe26a439b16a1f585d2de133540549831f8e774"},
+    {file = "regex-2022.3.15-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b7494df3fdcc95a1f76cf134d00b54962dd83189520fd35b8fcd474c0aa616d"},
+    {file = "regex-2022.3.15-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5b1ceede92400b3acfebc1425937454aaf2c62cd5261a3fabd560c61e74f6da3"},
+    {file = "regex-2022.3.15-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0317eb6331146c524751354ebef76a7a531853d7207a4d760dfb5f553137a2a4"},
+    {file = "regex-2022.3.15-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:9c144405220c5ad3f5deab4c77f3e80d52e83804a6b48b6bed3d81a9a0238e4c"},
+    {file = "regex-2022.3.15-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:5b2e24f3ae03af3d8e8e6d824c891fea0ca9035c5d06ac194a2700373861a15c"},
+    {file = "regex-2022.3.15-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:f2c53f3af011393ab5ed9ab640fa0876757498aac188f782a0c620e33faa2a3d"},
+    {file = "regex-2022.3.15-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:060f9066d2177905203516c62c8ea0066c16c7342971d54204d4e51b13dfbe2e"},
+    {file = "regex-2022.3.15-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:530a3a16e57bd3ea0dff5ec2695c09632c9d6c549f5869d6cf639f5f7153fb9c"},
+    {file = "regex-2022.3.15-cp39-cp39-win32.whl", hash = "sha256:78ce90c50d0ec970bd0002462430e00d1ecfd1255218d52d08b3a143fe4bde18"},
+    {file = "regex-2022.3.15-cp39-cp39-win_amd64.whl", hash = "sha256:c5adc854764732dbd95a713f2e6c3e914e17f2ccdc331b9ecb777484c31f73b6"},
+    {file = "regex-2022.3.15.tar.gz", hash = "sha256:0a7b75cc7bb4cc0334380053e4671c560e31272c9d2d5a6c4b8e9ae2c9bd0f82"},
 ]
 six = [
-    {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
-    {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 tomlkit = [
-    {file = "tomlkit-0.7.0-py2.py3-none-any.whl", hash = "sha256:6babbd33b17d5c9691896b0e68159215a9387ebfa938aa3ac42f4a4beeb2b831"},
-    {file = "tomlkit-0.7.0.tar.gz", hash = "sha256:ac57f29693fab3e309ea789252fcce3061e19110085aa31af5446ca749325618"},
+    {file = "tomlkit-0.7.2-py2.py3-none-any.whl", hash = "sha256:173ad840fa5d2aac140528ca1933c29791b79a374a0861a80347f42ec9328117"},
+    {file = "tomlkit-0.7.2.tar.gz", hash = "sha256:d7a454f319a7e9bd2e249f239168729327e4dd2d27b17dc68be264ad1ce36754"},
 ]
 typed-ast = [
-    {file = "typed_ast-1.4.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:73d785a950fc82dd2a25897d525d003f6378d1cb23ab305578394694202a58c3"},
-    {file = "typed_ast-1.4.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:aaee9905aee35ba5905cfb3c62f3e83b3bec7b39413f0a7f19be4e547ea01ebb"},
-    {file = "typed_ast-1.4.1-cp35-cp35m-win32.whl", hash = "sha256:0c2c07682d61a629b68433afb159376e24e5b2fd4641d35424e462169c0a7919"},
-    {file = "typed_ast-1.4.1-cp35-cp35m-win_amd64.whl", hash = "sha256:4083861b0aa07990b619bd7ddc365eb7fa4b817e99cf5f8d9cf21a42780f6e01"},
-    {file = "typed_ast-1.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75"},
-    {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652"},
-    {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"},
-    {file = "typed_ast-1.4.1-cp36-cp36m-win32.whl", hash = "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1"},
-    {file = "typed_ast-1.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa"},
-    {file = "typed_ast-1.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614"},
-    {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41"},
-    {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b"},
-    {file = "typed_ast-1.4.1-cp37-cp37m-win32.whl", hash = "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe"},
-    {file = "typed_ast-1.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355"},
-    {file = "typed_ast-1.4.1-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6"},
-    {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907"},
-    {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d"},
-    {file = "typed_ast-1.4.1-cp38-cp38-win32.whl", hash = "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c"},
-    {file = "typed_ast-1.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4"},
-    {file = "typed_ast-1.4.1-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34"},
-    {file = "typed_ast-1.4.1.tar.gz", hash = "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b"},
+    {file = "typed_ast-1.4.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:2068531575a125b87a41802130fa7e29f26c09a2833fea68d9a40cf33902eba6"},
+    {file = "typed_ast-1.4.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:c907f561b1e83e93fad565bac5ba9c22d96a54e7ea0267c708bffe863cbe4075"},
+    {file = "typed_ast-1.4.3-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:1b3ead4a96c9101bef08f9f7d1217c096f31667617b58de957f690c92378b528"},
+    {file = "typed_ast-1.4.3-cp35-cp35m-win32.whl", hash = "sha256:dde816ca9dac1d9c01dd504ea5967821606f02e510438120091b84e852367428"},
+    {file = "typed_ast-1.4.3-cp35-cp35m-win_amd64.whl", hash = "sha256:777a26c84bea6cd934422ac2e3b78863a37017618b6e5c08f92ef69853e765d3"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f8afcf15cc511ada719a88e013cec87c11aff7b91f019295eb4530f96fe5ef2f"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:52b1eb8c83f178ab787f3a4283f68258525f8d70f778a2f6dd54d3b5e5fb4341"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:01ae5f73431d21eead5015997ab41afa53aa1fbe252f9da060be5dad2c730ace"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:c190f0899e9f9f8b6b7863debfb739abcb21a5c054f911ca3596d12b8a4c4c7f"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-win32.whl", hash = "sha256:398e44cd480f4d2b7ee8d98385ca104e35c81525dd98c519acff1b79bdaac363"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-win_amd64.whl", hash = "sha256:bff6ad71c81b3bba8fa35f0f1921fb24ff4476235a6e94a26ada2e54370e6da7"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0fb71b8c643187d7492c1f8352f2c15b4c4af3f6338f21681d3681b3dc31a266"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:760ad187b1041a154f0e4d0f6aae3e40fdb51d6de16e5c99aedadd9246450e9e"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:5feca99c17af94057417d744607b82dd0a664fd5e4ca98061480fd8b14b18d04"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:95431a26309a21874005845c21118c83991c63ea800dd44843e42a916aec5899"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-win32.whl", hash = "sha256:aee0c1256be6c07bd3e1263ff920c325b59849dc95392a05f258bb9b259cf39c"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-win_amd64.whl", hash = "sha256:9ad2c92ec681e02baf81fdfa056fe0d818645efa9af1f1cd5fd6f1bd2bdfd805"},
+    {file = "typed_ast-1.4.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b36b4f3920103a25e1d5d024d155c504080959582b928e91cb608a65c3a49e1a"},
+    {file = "typed_ast-1.4.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:067a74454df670dcaa4e59349a2e5c81e567d8d65458d480a5b3dfecec08c5ff"},
+    {file = "typed_ast-1.4.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7538e495704e2ccda9b234b82423a4038f324f3a10c43bc088a1636180f11a41"},
+    {file = "typed_ast-1.4.3-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:af3d4a73793725138d6b334d9d247ce7e5f084d96284ed23f22ee626a7b88e39"},
+    {file = "typed_ast-1.4.3-cp38-cp38-win32.whl", hash = "sha256:f2362f3cb0f3172c42938946dbc5b7843c2a28aec307c49100c8b38764eb6927"},
+    {file = "typed_ast-1.4.3-cp38-cp38-win_amd64.whl", hash = "sha256:dd4a21253f42b8d2b48410cb31fe501d32f8b9fbeb1f55063ad102fe9c425e40"},
+    {file = "typed_ast-1.4.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f328adcfebed9f11301eaedfa48e15bdece9b519fb27e6a8c01aa52a17ec31b3"},
+    {file = "typed_ast-1.4.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:2c726c276d09fc5c414693a2de063f521052d9ea7c240ce553316f70656c84d4"},
+    {file = "typed_ast-1.4.3-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:cae53c389825d3b46fb37538441f75d6aecc4174f615d048321b716df2757fb0"},
+    {file = "typed_ast-1.4.3-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:b9574c6f03f685070d859e75c7f9eeca02d6933273b5e69572e5ff9d5e3931c3"},
+    {file = "typed_ast-1.4.3-cp39-cp39-win32.whl", hash = "sha256:209596a4ec71d990d71d5e0d312ac935d86930e6eecff6ccc7007fe54d703808"},
+    {file = "typed_ast-1.4.3-cp39-cp39-win_amd64.whl", hash = "sha256:9c6d1a54552b5330bc657b7ef0eae25d00ba7ffe85d9ea8ae6540d2197a3788c"},
+    {file = "typed_ast-1.4.3.tar.gz", hash = "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-3.7.4.3-py2-none-any.whl", hash = "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"},
-    {file = "typing_extensions-3.7.4.3-py3-none-any.whl", hash = "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918"},
-    {file = "typing_extensions-3.7.4.3.tar.gz", hash = "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c"},
+    {file = "typing_extensions-4.1.1-py3-none-any.whl", hash = "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"},
+    {file = "typing_extensions-4.1.1.tar.gz", hash = "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.2.1-py2.py3-none-any.whl", hash = "sha256:07cff122e9d343140366055f31be4dcd61fd598c69d11cd33a9d9c8df4546dd7"},
-    {file = "virtualenv-20.2.1.tar.gz", hash = "sha256:e0aac7525e880a429764cefd3aaaff54afb5d9f25c82627563603f5d7de5a6e5"},
+    {file = "virtualenv-20.13.4-py2.py3-none-any.whl", hash = "sha256:c3e01300fb8495bc00ed70741f5271fc95fed067eb7106297be73d30879af60c"},
+    {file = "virtualenv-20.13.4.tar.gz", hash = "sha256:ce8901d3bbf3b90393498187f2d56797a8a452fb2d0d7efc6fd837554d6f679c"},
 ]
 zipp = [
-    {file = "zipp-3.4.0-py3-none-any.whl", hash = "sha256:102c24ef8f171fd729d46599845e95c7ab894a4cf45f5de11a44cc7444fb1108"},
-    {file = "zipp-3.4.0.tar.gz", hash = "sha256:ed5eee1974372595f9e416cc7bbeeb12335201d8081ca8a0743c954d4446e5cb"},
+    {file = "zipp-3.6.0-py3-none-any.whl", hash = "sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc"},
+    {file = "zipp-3.6.0.tar.gz", hash = "sha256:71c644c5369f4a6e07636f0aa966270449561fcea2e3d6747b8d23efaa9d7832"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ pre-commit = "^2.6.0"
 pytest = "^6.0.1"
 pytest_mock = "^3.3.1"
 numpy = "^1.19.4"
+click = "<=8.0.4"
 
 [tool.poetry.plugins.pytest11]
 snappiershot = "snappiershot.plugins.pytest"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ pre-commit = "^2.6.0"
 pytest = "^6.0.1"
 pytest_mock = "^3.3.1"
 numpy = "^1.19.4"
-click = "<=8.0.4"
 
 [tool.poetry.plugins.pytest11]
 snappiershot = "snappiershot.plugins.pytest"
@@ -52,6 +51,7 @@ snappiershot = "snappiershot.plugins.pytest"
 line-length = 92
 target-version = ['py36', 'py37', 'py38']
 exclude = '\.git|\.idea|\.venv|\.\*cache|\*\.egg-info'
+click = "<=8.0.4"
 
 [tool.coverage]
     [tool.coverage.report]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ importlib-metadata = { version = ">1.5.1", python = "<3.8" }
 tomlkit = "^0.7.0"
 pandas = { version = ">=0.20.0", optional = true}
 pprint_ordered_sets = "^1.0.0"
+pint = "^0.14"
 
 [tool.poetry.extras]
 pandas = ["pandas"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.6.1"
+python = "^3.6.2"
 importlib-metadata = { version = ">1.5.1", python = "<3.8" }
 tomlkit = "^0.7.0"
 pandas = { version = ">=0.20.0", optional = true}
@@ -34,7 +34,7 @@ pint = "^0.14"
 pandas = ["pandas"]
 
 [tool.poetry.dev-dependencies]
-black = "19.10b0"
+black = "^22.3.0"
 coverage = "^5.3"
 flake8 = "^3.8.3"
 mypy = "^0.782"
@@ -51,7 +51,6 @@ snappiershot = "snappiershot.plugins.pytest"
 line-length = 92
 target-version = ['py36', 'py37', 'py38']
 exclude = '\.git|\.idea|\.venv|\.\*cache|\*\.egg-info'
-click = "<=8.0.4"
 
 [tool.coverage]
     [tool.coverage.report]

--- a/snappiershot/compare.py
+++ b/snappiershot/compare.py
@@ -88,8 +88,8 @@ class ObjectComparison:
               Tracks the operations that need to be applied to self.value and self.expected
                 to obtain value and expected, respectively. Used for logging differences.
         """
-        # Specifically check if both are equal
-        if value != expected:
+        # Check if the string format of both are equal due to possibility of different registries
+        if value.__str__() != expected.__str__():
             message = f"Units not equal ({value} != {expected}). "
             return self.differences.add(operations, message)
 

--- a/snappiershot/compare.py
+++ b/snappiershot/compare.py
@@ -49,7 +49,7 @@ class ObjectComparison:
         if isinstance(expected, Unit):
             return self._compare_units(value, expected, operations=operations)
 
-        # Check the types of both objects (take care of float and float64 differently.
+        # Check the types of both objects (take care of float and float64 differently)
         if type(value) != type(expected) and not (
             isinstance(value, float) and isinstance(expected, float)
         ):

--- a/snappiershot/compare.py
+++ b/snappiershot/compare.py
@@ -46,7 +46,7 @@ class ObjectComparison:
                 to obtain value and expected, respectively. Used for logging differences.
         """
         # Special check for units since it's possible the types won't match even if they are equal objects
-        if isinstance(expected, Unit):
+        if isinstance(expected, Unit) or isinstance(value, Unit):
             return self._compare_units(value, expected, operations=operations)
 
         # Check the types of both objects

--- a/snappiershot/compare.py
+++ b/snappiershot/compare.py
@@ -49,9 +49,11 @@ class ObjectComparison:
         if isinstance(expected, Unit):
             return self._compare_units(value, expected, operations=operations)
 
-        # Check the types of both objects (take care of float and float64 differently)
+        # Check the types of both objects
         if type(value) != type(expected) and not (
-            isinstance(value, float) and isinstance(expected, float)
+            # Special case for float and float64 due to mismatch of type, but both being float instances
+            isinstance(value, float)
+            and isinstance(expected, float)
         ):
             message = f"Types not equal: {type(value)} != {type(expected)}"
             return self.differences.add(operations, message)

--- a/snappiershot/compare.py
+++ b/snappiershot/compare.py
@@ -9,7 +9,7 @@ from .config import Config
 
 
 class ObjectComparison:
-    """ Class for comparing two objects and logging differences between them. """
+    """Class for comparing two objects and logging differences between them."""
 
     def __init__(self, value: Any, expected: Any, config: Config, exact: bool = False):
         """
@@ -27,16 +27,16 @@ class ObjectComparison:
         self._compare(self.value, self.expected, operations=[])
 
     def __bool__(self) -> bool:
-        """ Returns True if no differences were detected. """
+        """Returns True if no differences were detected."""
         return not bool(self.differences.items)
 
     @property
     def equal(self) -> bool:
-        """ Returns True if no differences were detected. """
+        """Returns True if no differences were detected."""
         return bool(self)
 
     def _compare(self, value: Any, expected: Any, *, operations: List[Callable]) -> None:
-        """ Perform a recursive, almost-equals comparison between value and expected.
+        """Perform a recursive, almost-equals comparison between value and expected.
 
         Args:
             value: The object to be checked.
@@ -79,7 +79,7 @@ class ObjectComparison:
     def _compare_units(
         self, value: Unit, expected: Unit, *, operations: List[Callable] = None
     ) -> None:
-        """ Perform a recursive, almost-equals comparison between value and expected.
+        """Perform a recursive, almost-equals comparison between value and expected.
 
         This is a helper function for when the expected is a unit, it compares objects without checking type.
 
@@ -98,7 +98,7 @@ class ObjectComparison:
     def _compare_dicts(
         self, value: Dict, expected: Dict, *, operations: List[Callable] = None
     ) -> None:
-        """ Perform a recursive, almost-equals comparison between value and expected.
+        """Perform a recursive, almost-equals comparison between value and expected.
 
         This is a helper function for when both value and expected are dictionaries.
 
@@ -125,7 +125,7 @@ class ObjectComparison:
     def _compare_floats(
         self, value: float, expected: float, *, operations: List[Callable] = None
     ) -> None:
-        """ Perform an almost-equals comparison between value and expected.
+        """Perform an almost-equals comparison between value and expected.
 
         This is a helper function for when both value and expected are floats.
 
@@ -155,7 +155,7 @@ class ObjectComparison:
     def _compare_sequences(
         self, value: Sequence, expected: Sequence, *, operations: List[Callable] = None
     ) -> None:
-        """ Perform a recursive, almost-equals comparison between value and expected.
+        """Perform a recursive, almost-equals comparison between value and expected.
 
         This is a helper function for when both value and expected are sequences
           (ordered, indexable iterables).
@@ -183,7 +183,7 @@ class ObjectComparison:
     def _compare_sets(
         self, value: Set, expected: Set, *, operations: List[Callable] = None
     ) -> None:
-        """ Perform an exact-equals comparison between value and expected.
+        """Perform an exact-equals comparison between value and expected.
 
         This is a helper function for when both value and expected are sets.
 
@@ -205,7 +205,7 @@ class ObjectComparison:
 
 
 class _Differences:
-    """ Helper object for logging comparisons for the ObjectComparison class.
+    """Helper object for logging comparisons for the ObjectComparison class.
 
     Example:
         >>> value = dict(name="test", list=[(1, 2, 4)])
@@ -230,7 +230,7 @@ class _Differences:
         self.items: Dict[Tuple[Callable, ...], str] = dict()
 
     def add(self, operations: Iterable[Callable], message: str) -> None:
-        """ Add a difference to the log of differences.
+        """Add a difference to the log of differences.
 
         Args:
             operations: The operations that need to be applied to complex object to obtain

--- a/snappiershot/compare.py
+++ b/snappiershot/compare.py
@@ -91,7 +91,7 @@ class ObjectComparison:
                 to obtain value and expected, respectively. Used for logging differences.
         """
         # Check if the string format of both are equal due to possibility of different registries
-        if value.__str__() != expected.__str__():
+        if str(value) != str(expected):
             message = f"Units not equal ({value} != {expected}). "
             return self.differences.add(operations, message)
 

--- a/snappiershot/config.py
+++ b/snappiershot/config.py
@@ -15,7 +15,7 @@ DEFAULT_JSON_INDENT = 4
 
 
 class Config:
-    """ The configuration object used throughout the package. """
+    """The configuration object used throughout the package."""
 
     def __init__(
         self,
@@ -46,7 +46,7 @@ class Config:
 
     @classmethod
     def from_pyproject(cls, file: Path) -> "Config":
-        """ Create a Config object by parsing a pyproject.toml file.
+        """Create a Config object by parsing a pyproject.toml file.
 
         Args:
             file: The path to the pyproject.toml file, as a `pathlib.Path` object.
@@ -59,7 +59,7 @@ class Config:
         return Config(**tool_config)
 
     def _validate(self) -> None:
-        """ Validates the configuration.
+        """Validates the configuration.
 
         Raises:
             ValueError: If a configuration has an invalid value.
@@ -124,11 +124,11 @@ class Config:
             )
 
     def __eq__(self, other: Any) -> bool:
-        """ Check equality. """
+        """Check equality."""
         return isinstance(other, type(self)) and (vars(self) == vars(other))
 
     def __repr__(self) -> str:
-        """ Human-readable representation. """
+        """Human-readable representation."""
         return (
             "Config("
             f"file_format={self.file_format}, "
@@ -140,7 +140,7 @@ class Config:
 
 
 def find_pyproject_toml(source: PathType) -> Optional[Path]:
-    """ Travel up the tree of the provided source, looking for a pyproject.toml file.
+    """Travel up the tree of the provided source, looking for a pyproject.toml file.
 
     Args:
         source: A path to the source from which to start the search.

--- a/snappiershot/constants.py
+++ b/snappiershot/constants.py
@@ -2,7 +2,7 @@
 from types import SimpleNamespace
 
 ENCODING_FUNCTION_NAME = "__snapshot__"
-SPECIAL_ENCODING_FUNCTION_NAME = "__snapshotskip__"
+METADATA_ENCODING_OVERRIDE = "__metadata_override__"
 SNAPSHOT_DIRECTORY = ".snapshots"
 
 

--- a/snappiershot/constants.py
+++ b/snappiershot/constants.py
@@ -6,7 +6,7 @@ SNAPSHOT_DIRECTORY = ".snapshots"
 
 
 class SnapshotKeys(SimpleNamespace):
-    """ Centralized location for the names of the keys of the parsed snapshot file. """
+    """Centralized location for the names of the keys of the parsed snapshot file."""
 
     metadata = "metadata"
     tests = "tests"

--- a/snappiershot/constants.py
+++ b/snappiershot/constants.py
@@ -2,6 +2,7 @@
 from types import SimpleNamespace
 
 ENCODING_FUNCTION_NAME = "__snapshot__"
+SPECIAL_ENCODING_FUNCTION_NAME = "__snapshotskip__"
 SNAPSHOT_DIRECTORY = ".snapshots"
 
 

--- a/snappiershot/constants.py
+++ b/snappiershot/constants.py
@@ -1,8 +1,7 @@
 """ Constants used throughout the snappiershot package. """
 from types import SimpleNamespace
 
-ENCODING_FUNCTION_NAME = "__snapshot__"
-METADATA_ENCODING_OVERRIDE = "__metadata_override__"
+ENCODING_CLASS_OVERRIDE = "__snapshot__"
 SNAPSHOT_DIRECTORY = ".snapshots"
 
 

--- a/snappiershot/errors.py
+++ b/snappiershot/errors.py
@@ -2,4 +2,4 @@
 
 
 class SnappierShotWarning(UserWarning):
-    """ Custom UserWarning for the SnappierShot library. """
+    """Custom UserWarning for the SnappierShot library."""

--- a/snappiershot/inspection.py
+++ b/snappiershot/inspection.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Iterator, NamedTuple
 
 class CallerInfo(NamedTuple):
     # noinspection PyUnresolvedReferences
-    """ Information about the caller function.
+    """Information about the caller function.
 
     Args:
         file: The path to the file containing the caller function.
@@ -21,7 +21,7 @@ class CallerInfo(NamedTuple):
 
     @classmethod
     def from_call_stack(cls, frame_index: int = 2) -> "CallerInfo":
-        """ Collect the CallerInfo from the call stack.
+        """Collect the CallerInfo from the call stack.
 
         Args:
             frame_index: The index of the frame of the caller function.
@@ -101,7 +101,7 @@ class CallerInfo(NamedTuple):
 def recursive_yield_staticmethods(
     haystack: Dict[str, Any], function: str, file: str
 ) -> Iterator[FunctionType]:
-    """ Recursively attempt to sort through the haystack looking classes with
+    """Recursively attempt to sort through the haystack looking classes with
     staticmethods with the specified function name, and yields these functions.
 
     Args:
@@ -127,7 +127,7 @@ def recursive_yield_staticmethods(
 
 
 def has_caller_method(kls: object, function_name: str, function_code: CodeType) -> bool:
-    """ Determines the function with specified function name and code is a
+    """Determines the function with specified function name and code is a
     method of the specified class.
 
     Args:
@@ -143,7 +143,7 @@ def has_caller_method(kls: object, function_name: str, function_code: CodeType) 
 
 
 def is_staticmethod(kls: object, method: str) -> bool:
-    """ Determines if the method of the class is a staticmethod.
+    """Determines if the method of the class is a staticmethod.
 
     Args:
         kls: The class to test for the staticmethod.

--- a/snappiershot/plugins/pytest.py
+++ b/snappiershot/plugins/pytest.py
@@ -58,6 +58,16 @@ def pytest_configure(config: PytestConfig) -> None:
         # Construct a SnapshotTracker object that tracks the state of each snapshot.
         root_dir = Path(config.rootdir).resolve()
         test_paths = (Path(path).resolve().relative_to(root_dir) for path in config.args)
+        # TODO: Fix bug where snappiershot scrapes for snapshots in folders pytest has defined as norecurse
+        # This bug results in files being marked as unchecked that weren't even tested
+        # First attempt at writing new tuple shown below, but it doesn't work... something like this needs to be
+        # implemented though
+        # test_paths_no_recurse = (
+        #    x
+        #    for x in test_paths
+        #    if not any([val in x.parts for val in config.getini("norecursedirs")])
+        # )
+        # setattr(config.option, PACKAGE_TRACKER_OPTION, SnapshotTracker(*test_paths_no_recurse))
         setattr(config.option, PACKAGE_TRACKER_OPTION, SnapshotTracker(*test_paths))
 
 

--- a/snappiershot/plugins/pytest.py
+++ b/snappiershot/plugins/pytest.py
@@ -18,7 +18,7 @@ PACKAGE_FULL_DIFF_OPTION = "snappiershot_full_diff"
 
 
 def construct_snappiershot_config(pytest_config: PytestConfig) -> snappiershot.Config:
-    """ Attempt to construct a snappiershot.Config object from the pytest Config object.
+    """Attempt to construct a snappiershot.Config object from the pytest Config object.
 
     Uses various path locations stored in the pytest Config object to locate the
       any pyproject.toml files with snappiershot configurations.
@@ -37,7 +37,7 @@ def construct_snappiershot_config(pytest_config: PytestConfig) -> snappiershot.C
 
 
 def pytest_addoption(parser: PytestParser) -> None:
-    """ Add options to the pytest runner configurations. """
+    """Add options to the pytest runner configurations."""
     group = parser.getgroup("snappiershot")
     group.addoption(
         "--snappiershot-full-diff",
@@ -49,7 +49,7 @@ def pytest_addoption(parser: PytestParser) -> None:
 
 
 def pytest_configure(config: PytestConfig) -> None:
-    """ Snappiershot-specific configuration for the pytest runner. """
+    """Snappiershot-specific configuration for the pytest runner."""
     # Construct a default snappiershot.Config object during pytest initialization.
     setattr(config.option, PACKAGE_CONFIG_OPTION, construct_snappiershot_config(config))
 
@@ -74,7 +74,7 @@ def pytest_configure(config: PytestConfig) -> None:
 def pytest_terminal_summary(
     terminalreporter: TerminalReporter, config: PytestConfig
 ) -> None:
-    """ Add a summary to the end of the of the pytest output about snapshot statuses. """
+    """Add a summary to the end of the of the pytest output about snapshot statuses."""
     tracker: SnapshotTracker = config.getoption(PACKAGE_TRACKER_OPTION)
     status_report = tracker.get_status_report()
 
@@ -90,7 +90,7 @@ def pytest_terminal_summary(
 # noinspection PyShadowingNames
 @pytest.fixture(name="snapshot", scope="function")
 def _snapshot(request: FixtureRequest) -> Iterator[snappiershot.Snapshot]:
-    """ Pytest fixture with function-level scope that returns a
+    """Pytest fixture with function-level scope that returns a
     snappiershot.Snapshot object.
 
     Examples:

--- a/snappiershot/plugins/tracker.py
+++ b/snappiershot/plugins/tracker.py
@@ -25,7 +25,7 @@ from snappiershot.snapshot import SnapshotMetadata, SnapshotStatus
 
 
 class StatusReport(NamedTuple):
-    """ NamedTuple for returning a status report for the snapshot testing session. """
+    """NamedTuple for returning a status report for the snapshot testing session."""
 
     unchecked: int = 0
     failed: int = 0
@@ -34,14 +34,14 @@ class StatusReport(NamedTuple):
     written: int = 0
 
     def any(self) -> bool:
-        """ Return a boolean that is False if all status reports are zero, else True. """
+        """Return a boolean that is False if all status reports are zero, else True."""
         return bool(
             self.unchecked or self.failed or self.passed or self.recorded or self.written
         )
 
 
 class SnapshotTracker:
-    """ Class used to track snapshot status throughout an entire test-run session. """
+    """Class used to track snapshot status throughout an entire test-run session."""
 
     def __init__(self, *paths: Path):
         """
@@ -58,7 +58,7 @@ class SnapshotTracker:
         self.snapshots = self._construct()
 
     def get_status_report(self) -> StatusReport:
-        """ Return the status report. """
+        """Return the status report."""
         unchecked = failed = passed = recorded = written = 0
         for file, functions in self.snapshots.items():
             for function_name, function_calls in functions.items():
@@ -85,7 +85,7 @@ class SnapshotTracker:
         function_name: str,
         metadata: SnapshotMetadata,
     ) -> None:
-        """ Set the statuses an individual snapshot run.
+        """Set the statuses an individual snapshot run.
 
         Args:
             statuses: The statuses of the snapshot files for a particular test function.
@@ -114,7 +114,7 @@ class SnapshotTracker:
         function_snapshots.append(dict(metadata=metadata.as_dict(), snapshots=statuses))
 
     def _construct(self) -> Dict:
-        """ Construct the underlying data structure for tracking snapshots.
+        """Construct the underlying data structure for tracking snapshots.
 
         This format of tracker largely follows the structure of
           the snapshot (JSON) file format:

--- a/snappiershot/serializers/constants.py
+++ b/snappiershot/serializers/constants.py
@@ -5,6 +5,8 @@ from decimal import Decimal
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any, Dict, Iterator, List, NamedTuple, Set, Union
 
+from pint import Unit
+
 _Primitive = Union[bool, float, int, None, str]
 JsonType = Union[_Primitive, Dict[str, Any], List[Any]]
 
@@ -178,12 +180,31 @@ class CustomEncodedPathTypes(_CustomEncodedTypeCollection):
     )
 
 
+class CustomEncodedUnitTypes(_CustomEncodedTypeCollection):
+    """ Collection of custom-encoded Unit types from the pint package. """
+
+    # Corresponds to the _CustomEncodedType.type_key attribute.
+    type_key = "__snappiershot_unit__"
+    # Corresponds to the _CustomEncodedType.value_key attribute.
+    value_key = "value"
+
+    unit = _CustomEncodedType(
+        type_=Unit, name="Unit", type_key=type_key, value_key=value_key
+    )
+
+
 # Tuples of types intended to be used for isinstance checking.
 PRIMITIVE_TYPES = bool, float, int, type(None), str
 COLLECTION_TYPES = tuple(value.type for value in CustomEncodedCollectionTypes.list())
 DATETIME_TYPES = tuple(value.type for value in CustomEncodedDatetimeTypes.list())
 NUMERIC_TYPES = tuple(value.type for value in CustomEncodedNumericTypes.list())
 PATH_TYPES = PurePosixPath, PureWindowsPath, Path
+UNIT_TYPES = tuple(value.type for value in CustomEncodedUnitTypes.list())
 SERIALIZABLE_TYPES = (
-    PRIMITIVE_TYPES + COLLECTION_TYPES + DATETIME_TYPES + NUMERIC_TYPES + PATH_TYPES
+    PRIMITIVE_TYPES
+    + COLLECTION_TYPES
+    + DATETIME_TYPES
+    + NUMERIC_TYPES
+    + PATH_TYPES
+    + UNIT_TYPES
 )

--- a/snappiershot/serializers/constants.py
+++ b/snappiershot/serializers/constants.py
@@ -13,7 +13,7 @@ JsonType = Union[_Primitive, Dict[str, Any], List[Any]]
 
 # noinspection PyUnresolvedReferences
 class _CustomEncodedType(NamedTuple):
-    """ Organizational object for holding information for serializing and de-serializing
+    """Organizational object for holding information for serializing and de-serializing
     custom-encoded types.
 
     See the ``json_encoding` method for an example of how this information is used.
@@ -35,11 +35,11 @@ class _CustomEncodedType(NamedTuple):
 
     @property
     def type(self) -> type:
-        """ Pass-through property to access the "type_" attribute. """
+        """Pass-through property to access the "type_" attribute."""
         return self.type_
 
     def json_encoding(self, encoded_value: JsonType) -> JsonType:
-        """ Use the specified encoded value to create the JSON encoding.
+        """Use the specified encoded value to create the JSON encoding.
 
         Args:
             encoded_value: An encoded value that is serializable into JSON.
@@ -48,7 +48,7 @@ class _CustomEncodedType(NamedTuple):
 
 
 class _CustomEncodedTypeCollection(ABC):
-    """ Abstract base class for CustomEncoded<group>Types classes.
+    """Abstract base class for CustomEncoded<group>Types classes.
 
     The _CustomEncodedTypes associated with the child classes are expected to
       be defined as class attributes. See:
@@ -67,7 +67,7 @@ class _CustomEncodedTypeCollection(ABC):
 
     @classmethod
     def list(cls) -> Iterator[_CustomEncodedType]:
-        """ Returns an iterator of all _CustomEncodedType objects defined
+        """Returns an iterator of all _CustomEncodedType objects defined
         as class attributes.
         """
         return (
@@ -76,12 +76,12 @@ class _CustomEncodedTypeCollection(ABC):
 
     @classmethod
     def keys(cls) -> Set[str]:
-        """ Returns a set of {type_key, value_key}. """
+        """Returns a set of {type_key, value_key}."""
         return {cls.type_key, cls.value_key}
 
 
 class CustomEncodedNumericTypes(_CustomEncodedTypeCollection):
-    """ Collection of custom-encoded numeric types. """
+    """Collection of custom-encoded numeric types."""
 
     # Corresponds to the _CustomEncodedType.type_key attribute.
     type_key = "__snappiershot_numeric__"
@@ -97,7 +97,7 @@ class CustomEncodedNumericTypes(_CustomEncodedTypeCollection):
 
 
 class CustomEncodedDatetimeTypes(_CustomEncodedTypeCollection):
-    """ Collection of custom-encoded datetime types. """
+    """Collection of custom-encoded datetime types."""
 
     # Corresponds to the _CustomEncodedType.type_key attribute.
     type_key = "__snappiershot_datetime__"
@@ -138,7 +138,7 @@ class CustomEncodedDatetimeTypes(_CustomEncodedTypeCollection):
 
 
 class CustomEncodedCollectionTypes(_CustomEncodedTypeCollection):
-    """ Collection of custom-encoded collection types. """
+    """Collection of custom-encoded collection types."""
 
     # Corresponds to the _CustomEncodedType.type_key attribute.
     type_key = "__snappiershot_collection__"
@@ -155,11 +155,11 @@ class CustomEncodedCollectionTypes(_CustomEncodedTypeCollection):
 
 
 class _UnavailableType:
-    """ Empty class for handling optional type dependencies that are unavailable """
+    """Empty class for handling optional type dependencies that are unavailable"""
 
 
 class CustomEncodedPathTypes(_CustomEncodedTypeCollection):
-    """ Collection of custom-encoded Path types. """
+    """Collection of custom-encoded Path types."""
 
     # Corresponds to the _CustomEncodedType.type_key attribute.
     type_key = "__snappiershot_path__"
@@ -181,7 +181,7 @@ class CustomEncodedPathTypes(_CustomEncodedTypeCollection):
 
 
 class CustomEncodedUnitTypes(_CustomEncodedTypeCollection):
-    """ Collection of custom-encoded Unit types from the pint package. """
+    """Collection of custom-encoded Unit types from the pint package."""
 
     # Corresponds to the _CustomEncodedType.type_key attribute.
     type_key = "__snappiershot_unit__"

--- a/snappiershot/serializers/constants.py
+++ b/snappiershot/serializers/constants.py
@@ -16,7 +16,7 @@ class _CustomEncodedType(NamedTuple):
     """Organizational object for holding information for serializing and de-serializing
     custom-encoded types.
 
-    See the ``json_encoding` method for an example of how this information is used.
+    See the `json_encoding` method for an example of how this information is used.
 
     Args:
         type_: The type object (constructor) for the type.

--- a/snappiershot/serializers/io.py
+++ b/snappiershot/serializers/io.py
@@ -8,7 +8,7 @@ from .json import JsonDeserializer, JsonSerializer, JsonType
 
 
 def parse_snapshot_file(snapshot_file: Path) -> Dict:
-    """ Parses the snapshot file.
+    """Parses the snapshot file.
 
     Args:
         snapshot_file: The path to the file containing snapshots.
@@ -33,7 +33,7 @@ def parse_snapshot_file(snapshot_file: Path) -> Dict:
 
 
 def write_json_file(obj: JsonType, file: Path, indent: Optional[int] = None) -> None:
-    """ Safely write a JSON file using the JsonSerializer.
+    """Safely write a JSON file using the JsonSerializer.
 
     The file will first be written to a temporary file to avoid partial writing and
       errors during writing. Then the temporary file is moved to the specified location.

--- a/snappiershot/serializers/json.py
+++ b/snappiershot/serializers/json.py
@@ -505,7 +505,7 @@ class JsonDeserializer(json.JSONDecoder):
         )
 
     @staticmethod
-    def decode_unit(dct: Dict[str, Any]) -> Unit:
+    def decode_unit(dct: Dict[str, Any]) -> str:
         """Decode an encoded Unit type from pint.
 
         This encoded Unit type object must be of the form:
@@ -520,7 +520,7 @@ class JsonDeserializer(json.JSONDecoder):
             dct: dictionary to decode
 
         Returns:
-            Decoded Unit object.
+            Decoded Unit object as a string due to inability to compare units of different registries.
 
         Raises:
             NotImplementedError - If decoding is not implemented for the given Unit type.

--- a/snappiershot/serializers/json.py
+++ b/snappiershot/serializers/json.py
@@ -8,7 +8,7 @@ from typing import Any, Collection, Dict, Iterator, List
 
 from pint import Unit
 
-from ..constants import SPECIAL_ENCODING_FUNCTION_NAME
+from ..constants import METADATA_ENCODING_OVERRIDE
 from .constants import (
     COLLECTION_TYPES,
     DATETIME_TYPES,
@@ -106,8 +106,8 @@ class JsonSerializer(json.JSONEncoder):
         # If the value is a class that hasn't been instantiated but want to still encode it somehow
         if is_uninstantiated_object(value):
             # Look for the special encoding function
-            if hasattr(value, SPECIAL_ENCODING_FUNCTION_NAME):
-                return getattr(value, SPECIAL_ENCODING_FUNCTION_NAME)()
+            if hasattr(value, METADATA_ENCODING_OVERRIDE):
+                return getattr(value, METADATA_ENCODING_OVERRIDE)()
 
         raise NotImplementedError(  # pragma: no cover
             f"Encoding for this object is not yet implemented: {value} ({type(value)})"

--- a/snappiershot/serializers/json.py
+++ b/snappiershot/serializers/json.py
@@ -23,7 +23,7 @@ from .constants import (
 
 
 class JsonSerializer(json.JSONEncoder):
-    """ Custom JSON serializer.
+    """Custom JSON serializer.
 
     Examples:
         >>> import json
@@ -34,7 +34,7 @@ class JsonSerializer(json.JSONEncoder):
 
     @classmethod
     def _hint_tuples(cls, obj: Any) -> Any:
-        """ Convert tuples in a pre-processing step.
+        """Convert tuples in a pre-processing step.
 
         Extrapolated from: https://stackoverflow.com/a/15721641
         """
@@ -72,7 +72,7 @@ class JsonSerializer(json.JSONEncoder):
         return super().iterencode(self._hint_tuples(obj), _one_shot)
 
     def default(self, value: Any) -> Any:
-        """ Encode a value into a serializable object.
+        """Encode a value into a serializable object.
 
         This method only gets called when the value is not naturally-serializable.
           (Naturally serializable objects are booleans, floats, strings, etc.)
@@ -107,7 +107,7 @@ class JsonSerializer(json.JSONEncoder):
 
     @staticmethod
     def encode_numeric(value: Number) -> JsonType:
-        """ Encoding for numeric types.
+        """Encoding for numeric types.
 
         This will do nothing to naturally serializable types (bool, int, float)
           but will perform custom encoding for non-supported types (complex).
@@ -139,7 +139,7 @@ class JsonSerializer(json.JSONEncoder):
 
     @staticmethod
     def encode_datetime(value: Any) -> JsonType:
-        """ Encoding for datetime types
+        """Encoding for datetime types
 
         This will perform custom encoding for datetime types
 
@@ -212,7 +212,7 @@ class JsonSerializer(json.JSONEncoder):
 
     @staticmethod
     def encode_collection(value: Collection) -> JsonType:
-        """ Encoding for collection types.
+        """Encoding for collection types.
 
         The custom encoding follows the template:
             {
@@ -240,7 +240,7 @@ class JsonSerializer(json.JSONEncoder):
 
     @staticmethod
     def encode_path(value: PurePath) -> JsonType:
-        """ Encoding for Path types
+        """Encoding for Path types
 
         This will perform custom encoding for all Path types, as all Path types are subclasses of the PurePath type.
         Instances of the PurePath type are handled separately from instances of the Path type.
@@ -281,7 +281,7 @@ class JsonSerializer(json.JSONEncoder):
 
     @staticmethod
     def encode_unit(value: Unit) -> JsonType:
-        """ Encoding for Unit types coming from the pint package
+        """Encoding for Unit types coming from the pint package
 
         The custom encoding follows the template:
             {
@@ -311,7 +311,7 @@ class JsonSerializer(json.JSONEncoder):
 
 
 class JsonDeserializer(json.JSONDecoder):
-    """ Custom JSON deserializer.
+    """Custom JSON deserializer.
 
     Examples:
         >>> import json
@@ -321,14 +321,14 @@ class JsonDeserializer(json.JSONDecoder):
     """
 
     def __init__(self, **kwargs: Any):
-        """ Hooks into the __init__ method of json.JSONDecoder.
+        """Hooks into the __init__ method of json.JSONDecoder.
 
         This is only expected to be called by the `json.loads` method.
         """
         super().__init__(object_hook=self.object_hook, **kwargs)
 
     def object_hook(self, dct: Dict[str, Any]) -> Any:
-        """ Decodes the dictionary into an object.
+        """Decodes the dictionary into an object.
 
         Custom decoding is done here, for the custom encodings that occurred within
           the `snappiershot.serializers.json.JsonSerializer.default` method.
@@ -352,7 +352,7 @@ class JsonDeserializer(json.JSONDecoder):
 
     @staticmethod
     def decode_numeric(dct: Dict[str, Any]) -> Any:
-        """ Decode an encoded numeric type.
+        """Decode an encoded numeric type.
 
         This encoded numeric type object must be of the form:
             {
@@ -381,7 +381,7 @@ class JsonDeserializer(json.JSONDecoder):
 
     @staticmethod
     def decode_datetime(dct: Dict[str, Any]) -> Any:
-        """ Decode an encoded datetime type
+        """Decode an encoded datetime type
 
         This encoded numeric type object must be of the form:
             {
@@ -433,7 +433,7 @@ class JsonDeserializer(json.JSONDecoder):
 
     @staticmethod
     def decode_collection(dct: Dict[str, Any]) -> Collection:
-        """ Decode an encoded collection type.
+        """Decode an encoded collection type.
 
         This encoded numeric type object must be of the form:
             {
@@ -470,7 +470,7 @@ class JsonDeserializer(json.JSONDecoder):
 
     @staticmethod
     def decode_path(dct: Dict[str, Any]) -> PurePath:
-        """ Decode an encoded Path type.
+        """Decode an encoded Path type.
 
         This encoded Path type object must be of the form:
             {
@@ -506,7 +506,7 @@ class JsonDeserializer(json.JSONDecoder):
 
     @staticmethod
     def decode_unit(dct: Dict[str, Any]) -> Unit:
-        """ Decode an encoded Unit type from pint.
+        """Decode an encoded Unit type from pint.
 
         This encoded Unit type object must be of the form:
             {

--- a/snappiershot/serializers/optional_module_utils.py
+++ b/snappiershot/serializers/optional_module_utils.py
@@ -21,7 +21,7 @@ class Pandas:
     def get_pandas(
         raise_error: bool = False, custom_error_message: str = ""
     ) -> Optional[ModuleType]:
-        """ Return pandas module, if it is already imported, otherwise return None
+        """Return pandas module, if it is already imported, otherwise return None
 
         Args:
             raise_error: if True, e.g. when pandas is required, raise an error
@@ -44,7 +44,7 @@ class Pandas:
 
     @classmethod
     def encode_pandas(cls, value: Any) -> EncodedPandasType:
-        """ Encoding given pandas object as a dictionary
+        """Encoding given pandas object as a dictionary
 
         Raises:
             NotImplementedError - If encoding is not implemented for the given pandas type.
@@ -121,7 +121,7 @@ class Numpy:
     def get_numpy(
         raise_error: bool = False, custom_error_message: str = ""
     ) -> Optional[ModuleType]:
-        """ Return numpy module, if it is already imported, otherwise return None
+        """Return numpy module, if it is already imported, otherwise return None
 
         Args:
             raise_error: if True, e.g. when numpy is required, raise an error
@@ -144,7 +144,7 @@ class Numpy:
 
     @classmethod
     def _get_numpy_primatives(cls, np: ModuleType) -> Tuple[type]:
-        """ Get numpy primative types
+        """Get numpy primative types
         Based on https://numpy.org/devdocs/user/basics.types.html
 
         Args:
@@ -164,7 +164,7 @@ class Numpy:
 
     @classmethod
     def encode_numpy(cls, value: Any) -> Any:
-        """ Encoding given numpy object
+        """Encoding given numpy object
 
         Raises:
             NotImplementedError - If encoding is not implemented for the given numpy type.

--- a/snappiershot/serializers/utils.py
+++ b/snappiershot/serializers/utils.py
@@ -15,11 +15,11 @@ from .optional_module_utils import Numpy, Pandas
 def filter_recursive_objects(
     func: Callable[[Any, Set[int]], JsonType]
 ) -> Callable[[Any, Optional[Set[int]]], JsonType]:
-    """ Decorator object for catching and tracking recursive objects. """
+    """Decorator object for catching and tracking recursive objects."""
 
     @wraps(func)
     def wrapper(value: Any, context: Optional[Set[int]] = None) -> JsonType:
-        """ Wrapper function to catch and track recursive objects. """
+        """Wrapper function to catch and track recursive objects."""
         if context is None:
             context = set()
 
@@ -36,7 +36,7 @@ def filter_recursive_objects(
 
 @filter_recursive_objects
 def default_encode_value(value: Any, context: Set[int]) -> JsonType:
-    """ Perform a default encoding of the specified value into a serializable data. """
+    """Perform a default encoding of the specified value into a serializable data."""
     # If the value is already serializable, return.
     if isinstance(value, SERIALIZABLE_TYPES):
         return value
@@ -103,7 +103,7 @@ def default_encode_value(value: Any, context: Set[int]) -> JsonType:
 
 
 def encode_exception(value: BaseException) -> JsonType:
-    """ Encode an exception object.
+    """Encode an exception object.
 
     These objects need to be specially handled because each exception has a unique
       hash and therefore cannot be automatically compared.
@@ -124,7 +124,7 @@ def encode_exception(value: BaseException) -> JsonType:
 
 
 def get_snapshot_file(test_file: Path, suffix: str) -> Path:
-    """ Returns the path to the snapshot file.
+    """Returns the path to the snapshot file.
 
     The SNAPSHOT_DIRECTORY will be created automatically if it does not exist.
 
@@ -150,7 +150,7 @@ def get_snapshot_file(test_file: Path, suffix: str) -> Path:
 
 
 def is_class_object(value: Any) -> bool:
-    """ Check if the input value is an instanced object, i.e. an instantiated class. """
+    """Check if the input value is an instanced object, i.e. an instantiated class."""
     is_type = inspect.isclass(value)
     is_function = inspect.isroutine(value)
     is_object = hasattr(value, "__dict__") or hasattr(value, "__slots__")
@@ -158,7 +158,7 @@ def is_class_object(value: Any) -> bool:
 
 
 def fullvars(value: Any) -> dict:
-    """ Returns a mapping of all attributes to their associated values for a given object.
+    """Returns a mapping of all attributes to their associated values for a given object.
     Supports slots-optimized classes.
 
     Args:

--- a/snappiershot/serializers/utils.py
+++ b/snappiershot/serializers/utils.py
@@ -8,8 +8,8 @@ from typing import Any, Callable, Dict, Optional, Sequence, Set
 
 from ..constants import (
     ENCODING_FUNCTION_NAME,
+    METADATA_ENCODING_OVERRIDE,
     SNAPSHOT_DIRECTORY,
-    SPECIAL_ENCODING_FUNCTION_NAME,
 )
 from ..errors import SnappierShotWarning
 from .constants import SERIALIZABLE_TYPES, JsonType
@@ -101,8 +101,8 @@ def default_encode_value(value: Any, context: Set[int]) -> JsonType:
     # If the value is a class that hasn't been instantiated but want to still encode it somehow
     if is_uninstantiated_object(value):
         # Look for the special encoding function
-        if hasattr(value, SPECIAL_ENCODING_FUNCTION_NAME):
-            return getattr(value, SPECIAL_ENCODING_FUNCTION_NAME)()
+        if hasattr(value, METADATA_ENCODING_OVERRIDE):
+            return getattr(value, METADATA_ENCODING_OVERRIDE)()
 
     raise ValueError(
         f"Cannot serialize this value: {value} \n"

--- a/snappiershot/serializers/utils.py
+++ b/snappiershot/serializers/utils.py
@@ -62,8 +62,8 @@ def default_encode_value(value: Any, context: Set[int]) -> JsonType:
     if isinstance(value, BaseException):
         return encode_exception(value)
 
-    # If the value is a sequence, recurse (unless it's an instanced object).
-    if isinstance(value, Sequence) and not is_class_object(value):
+    # If the value is a sequence, recurse.
+    if isinstance(value, Sequence):
         encoded_sequence = list()
         for item in value:
             try:

--- a/snappiershot/snapshot/_file.py
+++ b/snappiershot/snapshot/_file.py
@@ -13,7 +13,7 @@ _NO_SNAPSHOT = object()
 
 
 class _SnapshotFile:
-    """ Reads and Writes a snapshot file.
+    """Reads and Writes a snapshot file.
 
     This class performs the following actions at initialization:
         1. Locates the snapshot file associated with the test function
@@ -87,7 +87,7 @@ class _SnapshotFile:
         self._snapshot_statuses = [SnapshotStatus.UNCHECKED for _ in self._snapshots]
 
     def get_snapshot(self, index: int) -> Union[Dict, object]:
-        """ Return a snapshot from the snapshot file.
+        """Return a snapshot from the snapshot file.
 
         This snapshot will correspond to the test function, with the index
           corresponding to the nth assertion made by the test function.
@@ -103,15 +103,15 @@ class _SnapshotFile:
             return _NO_SNAPSHOT
 
     def mark_failed(self, index: int) -> None:
-        """ Set the status for the snapshot at the specified index as "FAILED". """
+        """Set the status for the snapshot at the specified index as "FAILED"."""
         self._mark_snapshot_status(index, SnapshotStatus.FAILED)
 
     def mark_passed(self, index: int) -> None:
-        """ Set the status for the snapshot at the specified index as "PASSED". """
+        """Set the status for the snapshot at the specified index as "PASSED"."""
         self._mark_snapshot_status(index, SnapshotStatus.PASSED)
 
     def record_snapshot(self, value: Any, index: int = -1) -> None:
-        """ Record a snapshot for the test function.
+        """Record a snapshot for the test function.
 
         Marks the snapshot at the given index as "RECORDED".
 
@@ -128,7 +128,7 @@ class _SnapshotFile:
         self._mark_snapshot_status(index, SnapshotStatus.RECORDED)
 
     def write(self) -> None:
-        """ Write out the snapshots.
+        """Write out the snapshots.
 
         Raises:
             ValueError: If the file format of the snapshot_file is not recognized.
@@ -153,7 +153,7 @@ class _SnapshotFile:
 
     @property
     def _empty_file_contents(self) -> Dict:
-        """ Returns the contents of an empty snapshot file.
+        """Returns the contents of an empty snapshot file.
 
         This value is used if a snapshot file does not exist.
         This needs to be within a property to avoid circular import limitations.
@@ -164,7 +164,7 @@ class _SnapshotFile:
 
     @staticmethod
     def _find_snapshots(file_contents: Dict, metadata: SnapshotMetadata) -> List[Dict]:
-        """ Finds the snapshots that correspond to the test function.
+        """Finds the snapshots that correspond to the test function.
 
         Will return an empty list of no snapshots are found.
 
@@ -195,7 +195,7 @@ class _SnapshotFile:
 
     @staticmethod
     def _get_snapshot_file(test_file: Path, file_format: str) -> Path:
-        """ Locates the snapshot file for the correct file format.
+        """Locates the snapshot file for the correct file format.
 
         Args:
             test_file: The path to the test file associated with the snapshot file.
@@ -209,7 +209,7 @@ class _SnapshotFile:
         raise ValueError(f"Unsupported snapshot file format: {file_format}")
 
     def _mark_snapshot_status(self, index: int, status: SnapshotStatus) -> None:
-        """ Set the status for the snapshot at the specified index as the specified status.
+        """Set the status for the snapshot at the specified index as the specified status.
 
         This will handle out-of-bounds indices.
         """
@@ -219,7 +219,7 @@ class _SnapshotFile:
             self._snapshot_statuses[index] = status
 
     def _parse_snapshot_file(self, snapshot_file: Path) -> Dict:
-        """ Parses the snapshot file.
+        """Parses the snapshot file.
 
         Args:
             snapshot_file: The path to the file containing snapshots.

--- a/snappiershot/snapshot/_raises.py
+++ b/snappiershot/snapshot/_raises.py
@@ -23,7 +23,7 @@ _ExceptionTypes = Union[Type[_E], Tuple[Type[_E], ...]]
 
 
 class _RaisesContext(Generic[_E]):
-    """ Context class used to track and snapshot raised exceptions. """
+    """Context class used to track and snapshot raised exceptions."""
 
     def __init__(
         self, snapshot: "Snapshot", expected_exceptions: _ExceptionTypes, update: bool
@@ -43,7 +43,7 @@ class _RaisesContext(Generic[_E]):
         self._assert_match = False
 
     def __enter__(self) -> "_RaisesContext":
-        """ Enter the context. """
+        """Enter the context."""
         return self
 
     def __exit__(
@@ -52,7 +52,7 @@ class _RaisesContext(Generic[_E]):
         exc_val: Optional[BaseException],
         exc_tb: Optional[TracebackType],
     ) -> bool:
-        """ Exit the context, checking exception types (if raised) and snapshotting.
+        """Exit the context, checking exception types (if raised) and snapshotting.
 
         Args:
             exc_type: The type of exception raised within the context (if exists).

--- a/snappiershot/snapshot/metadata.py
+++ b/snappiershot/snapshot/metadata.py
@@ -2,7 +2,6 @@
 from typing import Any, Dict
 
 from numpy import all, ndarray
-from snappiershot.constants import METADATA_ENCODING_OVERRIDE
 
 from ..inspection import CallerInfo
 
@@ -18,17 +17,12 @@ def compare_metadata(from_test_function: Any, from_snapshot: Any) -> bool:
         from_test_function: Inputs to the test function calling SnappierShot
         from_snapshot: Inputs to the test function after being serialized to JSON
     """
+    result = False
+
     # Determine if the metadata can instantiate a class from a dictionary, or whether any object is None
     metadata_function_has_method = hasattr(from_test_function, "from_dict")
     metadata_function_is_not_none = from_test_function is not None
     metadata_file_is_not_none = from_snapshot is not None
-
-    # If object has special coding defined to skip checking, set a flag
-    metadata_function_can_be_skipped = hasattr(
-        from_test_function, METADATA_ENCODING_OVERRIDE
-    )
-
-    result = False
 
     if isinstance(from_test_function, ndarray) or isinstance(from_snapshot, ndarray):
         result = all(from_test_function == from_snapshot)
@@ -37,16 +31,11 @@ def compare_metadata(from_test_function: Any, from_snapshot: Any) -> bool:
         result = from_test_function == from_snapshot
     elif (
         # Otherwise, if neither object is none and an object can be instantiated from a dictionary, do so
-        (metadata_function_has_method or metadata_function_can_be_skipped)
+        metadata_function_has_method
         and metadata_function_is_not_none
         and metadata_file_is_not_none
     ):
-        if metadata_function_can_be_skipped:
-            result = (
-                getattr(from_test_function, METADATA_ENCODING_OVERRIDE)() == from_snapshot
-            )
-        else:
-            result = from_test_function == from_test_function.from_dict(from_snapshot)
+        result = from_test_function == from_test_function.from_dict(from_snapshot)
 
     return result
 

--- a/snappiershot/snapshot/metadata.py
+++ b/snappiershot/snapshot/metadata.py
@@ -11,7 +11,7 @@ def compare_metadata(from_test_function: Any, from_snapshot: Any) -> bool:
 
     SnappierShot serializes class objects by decomposing them into their parts in the form of a dictionary, then
     writes to the snapshot JSON. Thus, SnappierShot must attempt to re-instantiate the dictionary form of the
-    objects when comparing inputs to a test function to those inputs serialized to JSON.
+    objects when comparing inputs to a test function to the stored metadata inputs already serialized to snapshot JSON.
 
     Args:
         from_test_function: Inputs to the test function calling SnappierShot

--- a/snappiershot/snapshot/metadata.py
+++ b/snappiershot/snapshot/metadata.py
@@ -86,18 +86,9 @@ class SnapshotMetadata:
             inputs_from_test_method = metadata_args.get(key)
             inputs_from_file = metadata_dict["arguments"].get(key)
 
-            # If the object is a list, must loop through it and compare each index
-            if isinstance(inputs_from_test_method, list) and isinstance(
-                inputs_from_file, list
-            ):
-                for ii, jj in zip(inputs_from_test_method, inputs_from_file):
-                    if not compare_metadata(ii, jj):
-                        # Early exit if objects arent equal
-                        return False
-            else:
-                if not compare_metadata(inputs_from_test_method, inputs_from_file):
-                    # Early exit if objects arent equal
-                    return False
+            if not compare_metadata(inputs_from_test_method, inputs_from_file):
+                # Early exit if objects arent equal
+                return False
 
         # If it made it through the checks, the objects are equal
         return True

--- a/snappiershot/snapshot/metadata.py
+++ b/snappiershot/snapshot/metadata.py
@@ -19,10 +19,8 @@ def compare_metadata(from_test_function: Any, from_snapshot: Any) -> bool:
     """
     result = False
 
-    # Determine if the metadata can instantiate a class from a dictionary, or whether any object is None
+    # Determine if the metadata can instantiate a class from a dictionary
     metadata_function_has_method = hasattr(from_test_function, "from_dict")
-    metadata_function_is_not_none = from_test_function is not None
-    metadata_file_is_not_none = from_snapshot is not None
 
     if isinstance(from_test_function, ndarray) or isinstance(from_snapshot, ndarray):
         # If at least one is a numpy array, elementwise comparison can be done like this:
@@ -33,8 +31,8 @@ def compare_metadata(from_test_function: Any, from_snapshot: Any) -> bool:
     elif (
         # Otherwise, if neither object is none and an object can be instantiated from a dictionary, do so
         metadata_function_has_method
-        and metadata_function_is_not_none
-        and metadata_file_is_not_none
+        and from_test_function is not None
+        and from_snapshot is not None
     ):
         result = from_test_function == from_test_function.from_dict(from_snapshot)
 

--- a/snappiershot/snapshot/metadata.py
+++ b/snappiershot/snapshot/metadata.py
@@ -25,6 +25,7 @@ def compare_metadata(from_test_function: Any, from_snapshot: Any) -> bool:
     metadata_file_is_not_none = from_snapshot is not None
 
     if isinstance(from_test_function, ndarray) or isinstance(from_snapshot, ndarray):
+        # If at least one is a numpy array, elementwise comparison can be done like this:
         result = all(from_test_function == from_snapshot)
     elif type(from_test_function) == type(from_snapshot):
         # If object types match, directly compare them

--- a/snappiershot/snapshot/metadata.py
+++ b/snappiershot/snapshot/metadata.py
@@ -7,7 +7,7 @@ from ..inspection import CallerInfo
 
 
 def compare_metadata(from_test_function: Any, from_snapshot: Any) -> bool:
-    """ Instantiate object from a dictionary read from file in order to compare to SnappierShot input.
+    """Instantiate object from a dictionary read from file in order to compare to SnappierShot input.
 
     SnappierShot serializes class objects by decomposing them into their parts in the form of a dictionary, then
     writes to the snapshot JSON. Thus, SnappierShot must attempt to re-instantiate the dictionary form of the
@@ -41,7 +41,7 @@ def compare_metadata(from_test_function: Any, from_snapshot: Any) -> bool:
 
 
 class SnapshotMetadata:
-    """ Metadata associated with a single snapshot. """
+    """Metadata associated with a single snapshot."""
 
     def __init__(
         self,
@@ -65,13 +65,13 @@ class SnapshotMetadata:
         self._validate()
 
     def as_dict(self) -> Dict:
-        """ Returns a JSON-serializable dictionary of metadata. """
+        """Returns a JSON-serializable dictionary of metadata."""
         dct = vars(self).copy()
         dct["arguments"] = dct.pop("caller_info").args
         return dct
 
     def matches(self, metadata_dict: Dict) -> bool:
-        """ Check if the "metadata" section of a snapshot file sufficiently matches
+        """Check if the "metadata" section of a snapshot file sufficiently matches
         the metadata object coming from the test method inputs.
 
         This matching is used to identify snapshots of tests within a snapshot file.
@@ -94,7 +94,7 @@ class SnapshotMetadata:
         return True
 
     def _validate(self) -> None:
-        """ Validates the snapshot metadata.
+        """Validates the snapshot metadata.
 
         Raises:
             TypeError: If a metadata field has an invalid type.

--- a/snappiershot/snapshot/metadata.py
+++ b/snappiershot/snapshot/metadata.py
@@ -70,10 +70,11 @@ class SnapshotMetadata:
         return dct
 
     def matches(self, metadata_dict: Dict) -> bool:
-        """Check if the "metadata" section of a snapshot file sufficiently matches
-        the metadata object coming from the test method inputs.
+        """Check if the "metadata" section of a snapshot file sufficiently matches the metadata object coming from the
+         test method inputs. This matching is used to identify snapshots of tests within a snapshot file.
 
-        This matching is used to identify snapshots of tests within a snapshot file.
+        Note, only test metadata is checked for matching snapshot inputs. Snapshot file metadata section may have extra
+        data not in test method inputs and this check will return True.
 
         Args:
             metadata_dict: The "metadata" section to compare against this object.

--- a/snappiershot/snapshot/snapshot.py
+++ b/snappiershot/snapshot/snapshot.py
@@ -20,7 +20,7 @@ class Snapshot:
     """Snapshot of a single assert value"""
 
     def __init__(self, configuration: Optional[Config] = None) -> None:
-        """ Initialize snapshot associated with a particular assert """
+        """Initialize snapshot associated with a particular assert"""
         self.configuration = configuration if configuration is not None else Config()
         self._snapshot_index = 0
         self._within_context = False
@@ -32,7 +32,7 @@ class Snapshot:
     def assert_match(
         self, value: Any, exact: bool = False, update: bool = False, ignore: List[str] = []
     ) -> bool:
-        """ Assert that the given value matches the snapshot on file
+        """Assert that the given value matches the snapshot on file
 
         Args:
             value: new value to compare to snapshot
@@ -99,7 +99,7 @@ class Snapshot:
     def raises(
         self, expected_exception: _ExceptionTypes, *, update: bool = False
     ) -> "_RaisesContext":
-        """ Assert that a code block raises an expected exception
+        """Assert that a code block raises an expected exception
         and snapshot the value of the raised exception.
 
         This is directly inspired by the ``pytest.raises`` method.
@@ -143,19 +143,19 @@ class Snapshot:
         return _RaisesContext(self, expected_exceptions, update)
 
     def __enter__(self) -> "Snapshot":
-        """ Enter the context of a Snapshot session. """
+        """Enter the context of a Snapshot session."""
         self._within_context = True
         return self
 
     def __exit__(self, *args: Any, **kwargs: Any) -> None:
-        """ Exits the context of the Snapshot session. """
+        """Exits the context of the Snapshot session."""
         if self._snapshot_file is not None:
             self._snapshot_file.write()
         self._within_context = False
 
     @staticmethod
     def _construct_diff(value: Any, expected: Any, comparison: ObjectComparison) -> str:
-        """ Construct the human-readable diff between two objects.
+        """Construct the human-readable diff between two objects.
 
         Args:
             value: The value to be diffed.
@@ -191,7 +191,7 @@ class Snapshot:
     def _get_metadata(
         self, update_on_next_run: bool, args_to_ignore: List[str]
     ) -> SnapshotMetadata:
-        """ Gather metadata via inspection of current context of the test function.
+        """Gather metadata via inspection of current context of the test function.
 
         A SnapshotMetadata object is created only if self._metadata is not already set.
         However, the "update_on_next_run" attribute is set every time.
@@ -220,7 +220,7 @@ class Snapshot:
         )
 
     def _load_snapshot_file(self, metadata: SnapshotMetadata) -> "_SnapshotFile":
-        """ Load the snapshot file into memory.
+        """Load the snapshot file into memory.
 
         The snapshot file is only loaded if self._snapshot_file is not already set.
 
@@ -233,7 +233,7 @@ class Snapshot:
 
     @classmethod
     def _remove_special_arguments(cls, caller_info: CallerInfo) -> CallerInfo:
-        """ Filter out the any arguments that shouldn't be used for metadata,
+        """Filter out the any arguments that shouldn't be used for metadata,
         such as the pytest "snapshot" fixture.
 
         Args:

--- a/snappiershot/snapshot/snapshot.py
+++ b/snappiershot/snapshot/snapshot.py
@@ -2,7 +2,7 @@
 import warnings
 from difflib import Differ
 from shutil import get_terminal_size
-from typing import Any, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
 import pprint_ordered_sets as pprint
 
@@ -30,7 +30,7 @@ class Snapshot:
         self._snapshot_file: Optional[_SnapshotFile] = None
 
     def assert_match(
-        self, value: Any, exact: bool = False, update: bool = False, ignore: list = []
+        self, value: Any, exact: bool = False, update: bool = False, ignore: List[str] = []
     ) -> bool:
         """ Assert that the given value matches the snapshot on file
 
@@ -189,7 +189,7 @@ class Snapshot:
         )
 
     def _get_metadata(
-        self, update_on_next_run: bool, args_to_ignore: list
+        self, update_on_next_run: bool, args_to_ignore: List[str]
     ) -> SnapshotMetadata:
         """ Gather metadata via inspection of current context of the test function.
 

--- a/snappiershot/snapshot/snapshot.py
+++ b/snappiershot/snapshot/snapshot.py
@@ -40,7 +40,7 @@ class Snapshot:
               otherwise assert approximate equality
             update: if True, overwrite snapshot with given value
               (assertion will always pass in this case)
-            ignore: if set, will ignore variables names from the metadata
+            ignore: optional argument ignores specified variables from the metadata
 
         Returns:
             True if value matches the snapshot

--- a/snappiershot/snapshot/snapshot.py
+++ b/snappiershot/snapshot/snapshot.py
@@ -30,7 +30,11 @@ class Snapshot:
         self._snapshot_file: Optional[_SnapshotFile] = None
 
     def assert_match(
-        self, value: Any, exact: bool = False, update: bool = False, ignore: List[str] = []
+        self,
+        value: Any,
+        exact: bool = False,
+        update: bool = False,
+        ignore: List[str] = None,
     ) -> bool:
         """Assert that the given value matches the snapshot on file
 
@@ -55,6 +59,9 @@ class Snapshot:
             >>> with Snapshot() as snapshot:
             >>>     snapshot.assert_match(result)
         """
+        if ignore is None:
+            ignore = []
+
         if not self._within_context:
             raise RuntimeError("assert_match must be used within the Snapshot context. ")
 

--- a/snappiershot/snapshot/status.py
+++ b/snappiershot/snapshot/status.py
@@ -3,7 +3,7 @@ from enum import IntEnum, auto
 
 
 class SnapshotStatus(IntEnum):
-    """ Enumeration of snapshot statuses.
+    """Enumeration of snapshot statuses.
 
     Unchecked -- The snapshot was discovered, but has not been asserted against.
     Failed    -- The snapshot assertion failed.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def warning_catcher() -> List[warnings.WarningMessage]:
-    """ Auto-used fixture for catching warning produced by the SnappierShot library.
+    """Auto-used fixture for catching warning produced by the SnappierShot library.
 
     Examples:
         ```python

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -14,7 +14,7 @@ REL_TOL = 0.001
 
 @pytest.fixture(name="config", scope="module")
 def _config() -> Config:
-    """ Fixture that returns a static Config object. """
+    """Fixture that returns a static Config object."""
     return Config(float_absolute_tolerance=ABS_TOL, float_relative_tolerance=REL_TOL)
 
 
@@ -26,7 +26,7 @@ def _config() -> Config:
     [(Unit("meter"), Unit("meter"), True), (Unit("meter"), Unit("feet"), False)],
 )
 def test_compare_units(value, expected, config, is_equal):
-    """ Test that units are compared as expected. """
+    """Test that units are compared as expected."""
     # Arrange
 
     # Act
@@ -45,7 +45,7 @@ def test_compare_units(value, expected, config, is_equal):
     ],
 )
 def test_compare_dictionaries(value, expected, config, is_equal):
-    """ Test that dictionaries are compared as expected. """
+    """Test that dictionaries are compared as expected."""
     # Arrange
 
     # Act
@@ -64,7 +64,7 @@ def test_compare_dictionaries(value, expected, config, is_equal):
     ],
 )
 def test_compare_sequences(value, expected, config, is_equal):
-    """ Test that sequences are compared as expected. """
+    """Test that sequences are compared as expected."""
     # Arrange
 
     # Act
@@ -84,7 +84,7 @@ def test_compare_sequences(value, expected, config, is_equal):
     ],
 )
 def test_compare_sets(value, expected, config, is_equal):
-    """ Test that sets are compared as expected. """
+    """Test that sets are compared as expected."""
     # Arrange
 
     # Act
@@ -107,7 +107,7 @@ def test_compare_sets(value, expected, config, is_equal):
     ],
 )
 def test_compare_floats(value, expected, config, exact, is_equal):
-    """ Test that floats are compared as expected. """
+    """Test that floats are compared as expected."""
     # Arrange
 
     # Act
@@ -118,7 +118,7 @@ def test_compare_floats(value, expected, config, exact, is_equal):
 
 
 def test_compare_types(config):
-    """ Test that objects of different types are caught. """
+    """Test that objects of different types are caught."""
     # Arrange
     value = None
     expected = 3.14
@@ -134,7 +134,7 @@ def test_compare_types(config):
 
 
 def test_compare(config):
-    """ Test comparison of complex object with itself (Integration test). """
+    """Test comparison of complex object with itself (Integration test)."""
     # Arrange
     value = {
         "string": "TEST",

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -23,7 +23,12 @@ def _config() -> Config:
 
 @pytest.mark.parametrize(
     "value, expected, is_equal",
-    [(Unit("meter"), Unit("meter"), True), (Unit("meter"), Unit("feet"), False)],
+    [
+        (Unit("meter"), Unit("meter"), True),
+        (Unit("meter"), Unit("feet"), False),
+        (Unit("meter"), "meter", True),
+        ("meter", Unit("meter"), True),
+    ],
 )
 def test_compare_units(value, expected, config, is_equal):
     """Test that units are compared as expected."""

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -32,9 +32,7 @@ def _config() -> Config:
 )
 def test_compare_units(value, expected, config, is_equal):
     """Test that units are compared as expected."""
-    # Arrange
-
-    # Act
+    # Arrange, Act
     comparison = ObjectComparison(value, expected, config)
 
     # Assert
@@ -51,9 +49,7 @@ def test_compare_units(value, expected, config, is_equal):
 )
 def test_compare_dictionaries(value, expected, config, is_equal):
     """Test that dictionaries are compared as expected."""
-    # Arrange
-
-    # Act
+    # Arrange, Act
     comparison = ObjectComparison(value, expected, config)
 
     # Assert
@@ -70,9 +66,7 @@ def test_compare_dictionaries(value, expected, config, is_equal):
 )
 def test_compare_sequences(value, expected, config, is_equal):
     """Test that sequences are compared as expected."""
-    # Arrange
-
-    # Act
+    # Arrange, Act
     comparison = ObjectComparison(value, expected, config)
 
     # Assert
@@ -90,9 +84,7 @@ def test_compare_sequences(value, expected, config, is_equal):
 )
 def test_compare_sets(value, expected, config, is_equal):
     """Test that sets are compared as expected."""
-    # Arrange
-
-    # Act
+    # Arrange, Act
     comparison = ObjectComparison(value, expected, config)
 
     # Assert
@@ -113,9 +105,7 @@ def test_compare_sets(value, expected, config, is_equal):
 )
 def test_compare_floats(value, expected, config, exact, is_equal):
     """Test that floats are compared as expected."""
-    # Arrange
-
-    # Act
+    # Arrange, Act
     comparison = ObjectComparison(value, expected, config, exact)
 
     # Assert

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -2,6 +2,7 @@
 from math import nan
 
 import pytest
+from pint.unit import Unit
 from snappiershot.compare import ObjectComparison
 from snappiershot.config import Config
 
@@ -18,6 +19,21 @@ def _config() -> Config:
 
 
 # ===== Unit Tests =========================================
+
+
+@pytest.mark.parametrize(
+    "value, expected, is_equal",
+    [(Unit("meter"), Unit("meter"), True), (Unit("meter"), Unit("feet"), False)],
+)
+def test_compare_units(value, expected, config, is_equal):
+    """ Test that units are compared as expected. """
+    # Arrange
+
+    # Act
+    comparison = ObjectComparison(value, expected, config)
+
+    # Assert
+    assert comparison.equal == is_equal
 
 
 @pytest.mark.parametrize(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,7 +27,7 @@ DEFAULT_CONFIG_KWARGS = dict(
 
 @pytest.fixture(name="pyproject_directory")
 def _pyproject_directory(tmp_path: Path) -> Path:
-    """ Fixture which creates the following directory structure in a temporary directory:
+    """Fixture which creates the following directory structure in a temporary directory:
 
     temp
       | - child
@@ -49,7 +49,7 @@ def _pyproject_directory(tmp_path: Path) -> Path:
 
 @pytest.mark.parametrize("parent_index, expected", [(0, True), (1, True), (2, False)])
 def test_find_pyproject_toml(parent_index: int, expected: bool, pyproject_directory: Path):
-    """ Test that the `snappiershot.config.find_pyproject_toml` function properly
+    """Test that the `snappiershot.config.find_pyproject_toml` function properly
     traverses the provided path searching for the pyproject.toml file.
     """
     # Arrange
@@ -76,8 +76,10 @@ def test_find_pyproject_toml(parent_index: int, expected: bool, pyproject_direct
     ]
 )
 # fmt: on
-def test_from_pyproject(contents: List[str], config_kwargs: Dict, pyproject_directory: Path):
-    """ Test that pyproject.toml files are parsed for configurations in a robust manner. """
+def test_from_pyproject(
+    contents: List[str], config_kwargs: Dict, pyproject_directory: Path
+):
+    """Test that pyproject.toml files are parsed for configurations in a robust manner."""
     # Arrange
     pyproject_toml = find_pyproject_toml(pyproject_directory)
     pyproject_toml.open("w").writelines((f"{line}\n" for line in contents))
@@ -102,10 +104,10 @@ def test_from_pyproject(contents: List[str], config_kwargs: Dict, pyproject_dire
         ({**DEFAULT_CONFIG_KWARGS, "full_diff": None}, TypeError),
         ({**DEFAULT_CONFIG_KWARGS, "json_indentation": -1}, ValueError),
         ({**DEFAULT_CONFIG_KWARGS, "json_indentation": 1.5}, TypeError),
-    ]
+    ],
 )
 def test_config_validate(config_kwargs: Dict, expected_error: Type[Exception]):
-    """ Checks that validation of the configuration values occurs as expected. """
+    """Checks that validation of the configuration values occurs as expected."""
     # Arrange
 
     # Act & Assert

--- a/tests/test_inspection.py
+++ b/tests/test_inspection.py
@@ -13,7 +13,7 @@ Result_Expected = Tuple[CallerInfo, CallerInfo]
 
 
 def get_caller_info(frame_index: int = 2) -> CallerInfo:
-    """ Calls the `snappiershot.inspection.CallerInfo.from_call_stack` method.
+    """Calls the `snappiershot.inspection.CallerInfo.from_call_stack` method.
 
     This simulates the expected call stack during normal snappiershot runtime.
 
@@ -24,7 +24,7 @@ def get_caller_info(frame_index: int = 2) -> CallerInfo:
 
 
 def single_function_no_args() -> Result_Expected:
-    """ Single function call, with no arguments. """
+    """Single function call, with no arguments."""
     expected = CallerInfo(FILE, "single_function_no_args", {})
     return get_caller_info(), expected
 
@@ -32,16 +32,16 @@ def single_function_no_args() -> Result_Expected:
 def single_function_with_args(
     foo: str = "FOO", bar: bool = True, pi: float = 3.14
 ) -> Result_Expected:
-    """ Single function call, with arguments. """
+    """Single function call, with arguments."""
     expected = CallerInfo(FILE, "single_function_with_args", dict(foo=foo, bar=bar, pi=pi))
     return get_caller_info(), expected
 
 
 def nested_function() -> Result_Expected:
-    """ Nested function call. """
+    """Nested function call."""
 
     def inner():
-        """ Inner (nested) function. """
+        """Inner (nested) function."""
         return get_caller_info(frame_index=3)
 
     expected = CallerInfo(FILE, "nested_function", {})
@@ -49,43 +49,43 @@ def nested_function() -> Result_Expected:
 
 
 class ClassTestObject:
-    """ Class used for housing more test objects. """
+    """Class used for housing more test objects."""
 
     # noinspection PyMethodMayBeStatic
     def method(self) -> Result_Expected:
-        """ Method call. """
+        """Method call."""
         expected = CallerInfo(FILE, "ClassTestObject.method", {})
         return get_caller_info(), expected
 
     @classmethod
     def classmethod_(cls) -> Result_Expected:
-        """ Class method call. """
+        """Class method call."""
         expected = CallerInfo(FILE, "ClassTestObject.classmethod_", {})
         return get_caller_info(), expected
 
     @staticmethod
     def staticmethod_() -> Result_Expected:
-        """ Static method call. """
+        """Static method call."""
         expected = CallerInfo(FILE, "ClassTestObject.staticmethod_", {})
         return get_caller_info(), expected
 
     # noinspection PyMethodMayBeStatic, PyMethodParameters
     def method_no_self_arg(notself) -> Result_Expected:
-        """ Method call, but the "self" argument is mis-named. """
+        """Method call, but the "self" argument is mis-named."""
         expected = CallerInfo(FILE, "ClassTestObject.method_no_self_arg", {})
         return get_caller_info(), expected
 
     # noinspection PyMethodParameters
     @classmethod
     def classmethod_no_self_arg(notcls) -> Result_Expected:
-        """ Class method call, but the "self" argument is mis-named. """
+        """Class method call, but the "self" argument is mis-named."""
         expected = CallerInfo(FILE, "ClassTestObject.classmethod_no_self_arg", {})
         return get_caller_info(), expected
 
     # noinspection PyUnusedLocal
     @staticmethod
     def staticmethod_self_arg(self=None) -> Result_Expected:
-        """ Static method call, but the first argument is "self". """
+        """Static method call, but the first argument is "self"."""
         expected = CallerInfo(
             FILE, "ClassTestObject.staticmethod_self_arg", dict(self=None)
         )
@@ -94,22 +94,22 @@ class ClassTestObject:
     # noinspection PyUnusedLocal
     @staticmethod
     def staticmethod_cls_arg(cls=None) -> Result_Expected:
-        """ Static method call, but the first argument is "cls". """
+        """Static method call, but the first argument is "cls"."""
         expected = CallerInfo(FILE, "ClassTestObject.staticmethod_cls_arg", dict(cls=None))
         return get_caller_info(), expected
 
     class NestedClass:
-        """ Nest class definition. """
+        """Nest class definition."""
 
         # noinspection PyMethodMayBeStatic
         def method(self) -> Result_Expected:
-            """ Method call within nested class definition. """
+            """Method call within nested class definition."""
             expected = CallerInfo(FILE, "ClassTestObject.NestedClass.method", {})
             return get_caller_info(), expected
 
         @staticmethod
         def staticmethod() -> Result_Expected:
-            """ Static method call. """
+            """Static method call."""
             expected = CallerInfo(FILE, "ClassTestObject.NestedClass.staticmethod", {})
             return get_caller_info(), expected
 
@@ -135,7 +135,7 @@ class ClassTestObject:
     ],
 )
 def test_caller_function_inspection(function: Callable[..., Result_Expected]):
-    """ Tests that the CallerInfo.from_call_stack method can correctly extract
+    """Tests that the CallerInfo.from_call_stack method can correctly extract
     information about the caller function.
 
     Args:
@@ -153,14 +153,14 @@ def test_caller_function_inspection(function: Callable[..., Result_Expected]):
 
 
 def test_caller_function_inspection_inner_function_error():
-    """ Tests that the CallerInfo.from_call_stack method raises an error if
+    """Tests that the CallerInfo.from_call_stack method raises an error if
     it cannot determine the caller function due to that function being defined
     within another functions scope.
     """
     # Arrange
 
     def inner():
-        """ Inner function definition. """
+        """Inner function definition."""
         CallerInfo.from_call_stack(1)
 
     # Act & Assert
@@ -182,7 +182,7 @@ def test_caller_function_inspection_inner_function_error():
     ],
 )
 def test_is_staticmethod(cls: object, method: str, expected: bool):
-    """ Tests that the is_staticmethod function correctly identifies staticmethod. """
+    """Tests that the is_staticmethod function correctly identifies staticmethod."""
     # Arrange
 
     # Act

--- a/tests/test_plugins/pytester_example_dir/.snapshots/test_file_3.json
+++ b/tests/test_plugins/pytester_example_dir/.snapshots/test_file_3.json
@@ -12,25 +12,16 @@
                 "snapshots": [
                     {
                         "test1": {
-                            "unit": {
-                                "__snappiershot_unit__": "Unit",
-                                "value": "meter"
-                            },
+                            "unit": "meter",
                             "value": -1000
                         },
                         "test2": [
                             {
-                                "unit": {
-                                    "__snappiershot_unit__": "Unit",
-                                    "value": "meter"
-                                },
+                                "unit": "meter",
                                 "value": -1000
                             },
                             {
-                                "unit": {
-                                    "__snappiershot_unit__": "Unit",
-                                    "value": "meter"
-                                },
+                                "unit": "meter",
                                 "value": -1000
                             }
                         ]

--- a/tests/test_plugins/pytester_example_dir/.snapshots/test_file_3.json
+++ b/tests/test_plugins/pytester_example_dir/.snapshots/test_file_3.json
@@ -1,7 +1,7 @@
 {
     "snappiershot_version": "0.1.0",
     "tests": {
-        "test_complex_snapshot": [
+        "test_units_snapshot": [
             {
                 "metadata": {
                     "arguments": {},

--- a/tests/test_plugins/pytester_example_dir/.snapshots/test_file_3.json
+++ b/tests/test_plugins/pytester_example_dir/.snapshots/test_file_3.json
@@ -1,0 +1,42 @@
+{
+    "snappiershot_version": "0.1.0",
+    "tests": {
+        "test_complex_snapshot": [
+            {
+                "metadata": {
+                    "arguments": {},
+                    "test_runner_provided_name": "",
+                    "update_on_next_run": false,
+                    "user_provided_name": ""
+                },
+                "snapshots": [
+                    {
+                        "test1": {
+                            "unit": {
+                                "__snappiershot_unit__": "Unit",
+                                "value": "meter"
+                            },
+                            "value": -1000
+                        },
+                        "test2": [
+                            {
+                                "unit": {
+                                    "__snappiershot_unit__": "Unit",
+                                    "value": "meter"
+                                },
+                                "value": -1000
+                            },
+                            {
+                                "unit": {
+                                    "__snappiershot_unit__": "Unit",
+                                    "value": "meter"
+                                },
+                                "value": -1000
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/tests/test_plugins/pytester_example_dir/test_file_1.py
+++ b/tests/test_plugins/pytester_example_dir/test_file_1.py
@@ -2,11 +2,11 @@
 
 
 def test_function_passed(snapshot):
-    """ The snapshot for this function is expected to exist. """
+    """The snapshot for this function is expected to exist."""
     snapshot.assert_match(3 + 4j)
 
 
 def test_function_new(snapshot):
-    """ The snapshot for this function is expected to exist, but only one assertion is expected. """
+    """The snapshot for this function is expected to exist, but only one assertion is expected."""
     snapshot.assert_match(3 + 4j)
     snapshot.assert_match(3 + 4j)

--- a/tests/test_plugins/pytester_example_dir/test_file_2.py
+++ b/tests/test_plugins/pytester_example_dir/test_file_2.py
@@ -4,10 +4,10 @@ import pytest
 
 @pytest.mark.xfail
 def test_function_fail(snapshot):
-    """ The snapshot for this function is expected to exist, but the assertion fails. """
+    """The snapshot for this function is expected to exist, but the assertion fails."""
     snapshot.assert_match(False)
 
 
 def test_function_write(snapshot):
-    """ The snapshot for this function is not expected to exist. """
+    """The snapshot for this function is not expected to exist."""
     snapshot.assert_match(3 + 4j)

--- a/tests/test_plugins/pytester_example_dir/test_file_3.py
+++ b/tests/test_plugins/pytester_example_dir/test_file_3.py
@@ -3,7 +3,7 @@ from pint.unit import Unit
 
 
 def test_units_snapshot(snapshot):
-    """ The snapshot for this function is expected to pass. """
+    """The snapshot for this function is expected to pass."""
 
     class HasUnits:
         def __init__(self):

--- a/tests/test_plugins/pytester_example_dir/test_file_3.py
+++ b/tests/test_plugins/pytester_example_dir/test_file_3.py
@@ -1,0 +1,18 @@
+""" This is a test file used for testing the pytest plugin. """
+from pint.unit import Unit
+
+
+def test_complex_snapshot(snapshot):
+    """ The snapshot for this function is expected to exist, but the assertion fails. """
+
+    class HasUnitsClass:
+        def __init__(self):
+            tmp_dict = {"unit": Unit("m"), "value": -1000}
+            tmp_list = [tmp_dict, tmp_dict]
+
+            self.test1 = tmp_dict
+            self.test2 = tmp_list
+
+    klass = HasUnitsClass()
+
+    snapshot.assert_match(klass)

--- a/tests/test_plugins/pytester_example_dir/test_file_3.py
+++ b/tests/test_plugins/pytester_example_dir/test_file_3.py
@@ -2,10 +2,10 @@
 from pint.unit import Unit
 
 
-def test_complex_snapshot(snapshot):
-    """ The snapshot for this function is expected to exist, but the assertion fails. """
+def test_units_snapshot(snapshot):
+    """ The snapshot for this function is expected to pass. """
 
-    class HasUnitsClass:
+    class HasUnits:
         def __init__(self):
             tmp_dict = {"unit": Unit("m"), "value": -1000}
             tmp_list = [tmp_dict, tmp_dict]
@@ -13,6 +13,6 @@ def test_complex_snapshot(snapshot):
             self.test1 = tmp_dict
             self.test2 = tmp_list
 
-    klass = HasUnitsClass()
+    obj = HasUnits()
 
-    snapshot.assert_match(klass)
+    snapshot.assert_match(obj)

--- a/tests/test_plugins/test_pytest.py
+++ b/tests/test_plugins/test_pytest.py
@@ -13,7 +13,7 @@ PYTESTER_EXAMPLE_DIR = Path(__file__).parent / "pytester_example_dir"
 
 @pytest.mark.filterwarnings("ignore:.*experimental api")
 def test_tracker(testdir: Testdir):
-    """ Test that the SnapshotTracker is able to track snapshot statuses
+    """Test that the SnapshotTracker is able to track snapshot statuses
     throughout a pytest run.
     """
     # Arrange

--- a/tests/test_plugins/test_pytest.py
+++ b/tests/test_plugins/test_pytest.py
@@ -21,8 +21,10 @@ def test_tracker(testdir: Testdir):
     copytree(PYTESTER_EXAMPLE_DIR / SNAPSHOT_DIRECTORY, testdir.tmpdir / SNAPSHOT_DIRECTORY)
     snapshot_file_1 = Path(testdir.tmpdir / ".snapshots" / "test_file_1.json")
     snapshot_file_2 = Path(testdir.tmpdir / ".snapshots" / "test_file_2.json")
+    snapshot_file_3 = Path(testdir.tmpdir / ".snapshots" / "test_file_3.json")
     testdir.copy_example("test_file_1.py")
     testdir.copy_example("test_file_2.py")
+    testdir.copy_example("test_file_3.py")
 
     # Act
     #   Run pytest on the testdir (as quietly as possible).
@@ -36,7 +38,7 @@ def test_tracker(testdir: Testdir):
     tracker = config.getoption(PACKAGE_TRACKER_OPTION)
 
     #   Assert that tracker collected the expected snapshot files.
-    assert tracker.snapshot_files == {snapshot_file_1, snapshot_file_2}
+    assert tracker.snapshot_files == {snapshot_file_1, snapshot_file_2, snapshot_file_3}
 
     #   Assert that the tracker has the expected statuses for all snapshots.
     metadata = dict(
@@ -67,5 +69,10 @@ def test_tracker(testdir: Testdir):
             "test_function_write": [
                 dict(metadata=metadata, snapshots=[SnapshotStatus.WRITTEN])
             ],
+        },
+        snapshot_file_3: {
+            "test_complex_snapshot": [
+                dict(metadata=metadata, snapshots=[SnapshotStatus.PASSED])
+            ]
         },
     }

--- a/tests/test_plugins/test_pytest.py
+++ b/tests/test_plugins/test_pytest.py
@@ -71,7 +71,7 @@ def test_tracker(testdir: Testdir):
             ],
         },
         snapshot_file_3: {
-            "test_complex_snapshot": [
+            "test_units_snapshot": [
                 dict(metadata=metadata, snapshots=[SnapshotStatus.PASSED])
             ]
         },

--- a/tests/test_plugins/test_tracker.py
+++ b/tests/test_plugins/test_tracker.py
@@ -7,7 +7,7 @@ from snappiershot.snapshot import SnapshotMetadata, SnapshotStatus
 
 
 def test_tracker_get_status_report():
-    """ Test that the SnapshotTracker.get_status_report method functions as expected. """
+    """Test that the SnapshotTracker.get_status_report method functions as expected."""
     # Arrange
     expected = StatusReport(1, 2, 3, 4, 5)
 
@@ -55,7 +55,7 @@ def test_tracker_get_status_report():
 
 
 def test_tracker_set_status():
-    """ Test that the SnapshotTracker.set_status method functions as expected. """
+    """Test that the SnapshotTracker.set_status method functions as expected."""
     # Arrange
     statuses = [
         SnapshotStatus.UNCHECKED,

--- a/tests/test_serializers/test_io.py
+++ b/tests/test_serializers/test_io.py
@@ -10,11 +10,11 @@ from snappiershot.serializers.io import (
 
 
 class TestParseSnapshotFile:
-    """ Tests for the parse_snapshot_file utility function. """
+    """Tests for the parse_snapshot_file utility function."""
 
     @staticmethod
     def test_parse_snapshot_file(tmp_path):
-        """ Test that parse_snapshot_file parses snapshot files as expected """
+        """Test that parse_snapshot_file parses snapshot files as expected"""
         # Arrange
         snapshot_file = tmp_path / "example_test.json"
         expected = {SnapshotKeys.version: "X.X.X", SnapshotKeys.tests: dict()}
@@ -28,7 +28,7 @@ class TestParseSnapshotFile:
 
     @staticmethod
     def test_parse_snapshot_file_format_error(tmp_path):
-        """ Test that parse_snapshot_file raises an error when attempting to parse
+        """Test that parse_snapshot_file raises an error when attempting to parse
         an unsupported file format for snapshot files.
         """
         # Arrange
@@ -43,7 +43,7 @@ class TestParseSnapshotFile:
         "contents", ["{}", '{"snappiershot_version": "X.X.X"}', '{"tests": {}}']
     )
     def test_parse_snapshot_file_error(contents: str, tmp_path):
-        """ Test that parse_snapshot_file raises an error when the contents of
+        """Test that parse_snapshot_file raises an error when the contents of
         the parsed snapshot file do not adhere to the snapshot file format.
 
         The snapshot format should be:
@@ -59,11 +59,11 @@ class TestParseSnapshotFile:
 
 
 class TestWritingToFile:
-    """ Tests for the file writing utility functions. """
+    """Tests for the file writing utility functions."""
 
     @staticmethod
     def test_write_json_error(tmp_path):
-        """ Test if an error occurs during snapshot writing, no file is written. """
+        """Test if an error occurs during snapshot writing, no file is written."""
         # Arrange
         obj = {("tuple as key",): None}
         snapshot_file = tmp_path / "snapshot_file.json"

--- a/tests/test_serializers/test_json.py
+++ b/tests/test_serializers/test_json.py
@@ -15,7 +15,6 @@ from snappiershot.serializers.constants import (
     CustomEncodedUnitTypes,
 )
 from snappiershot.serializers.json import JsonDeserializer, JsonSerializer
-from snappiershot.serializers.utils import default_encode_value
 
 
 class TestNumericEncoding:
@@ -306,8 +305,6 @@ class TestUnitEncoding:
 
     UNIT_DECODING_TEST_CASES = [
         (Unit("meter"), CustomEncodedUnitTypes.unit.json_encoding("meter"),),
-        ("fraction", CustomEncodedUnitTypes.unit.json_encoding("fraction")),
-        ("percent", CustomEncodedUnitTypes.unit.json_encoding("percent")),
     ]
 
     UNIT_ENCODING_TEST_CASES = UNIT_DECODING_TEST_CASES
@@ -362,8 +359,6 @@ class TestUninstantiatedClassEncoding:
 
     DECODING_TEST_CASES = [
         (Unit("meter"), CustomEncodedUnitTypes.unit.json_encoding("meter"),),
-        ("fraction", CustomEncodedUnitTypes.unit.json_encoding("fraction")),
-        ("percent", CustomEncodedUnitTypes.unit.json_encoding("percent")),
     ]
 
     @staticmethod
@@ -388,10 +383,6 @@ def test_round_trip(tmp_path: pathlib.Path):
             self.b = 2
 
         def __snapshot__(self):
-            return "Skip Me"
-
-        @classmethod
-        def __metadata_override__(cls):
             return "Skip Me"
 
     # Arrange
@@ -425,7 +416,6 @@ def test_round_trip(tmp_path: pathlib.Path):
         "pure_posix_Path": pathlib.PurePosixPath(),
         "bytes": b"bytes",
         "unit": Unit("meter"),
-        "skip": ClassWithSkip,
     }
     test_file = tmp_path / "test.json"
 
@@ -435,9 +425,6 @@ def test_round_trip(tmp_path: pathlib.Path):
 
     json.dump(data, test_file.open("w"), cls=JsonSerializer)
     deserialized_from_file = json.load(test_file.open(), cls=JsonDeserializer)
-
-    # Encode "skip" and "empty_dict"
-    data["skip"] = default_encode_value(data.get("skip"))  # type: ignore
 
     # Assert
     for key, value in deserialized.items():

--- a/tests/test_serializers/test_json.py
+++ b/tests/test_serializers/test_json.py
@@ -360,29 +360,6 @@ class TestUnitEncoding:
             JsonDeserializer.decode_unit(value)
 
 
-class TestUninstantiatedClassEncoding:
-    """Tests for custom encoding of special classes that haven't been instantiated."""
-
-    DECODING_TEST_CASES = [
-        (
-            Unit("meter"),
-            CustomEncodedUnitTypes.unit.json_encoding("meter"),
-        ),
-    ]
-
-    @staticmethod
-    @pytest.mark.parametrize("value, expected", DECODING_TEST_CASES)
-    def test_encode_uninstantiated_class(value, expected):
-        """Test that the JsonSerializer.default encodes special uninstantiated classes as expected."""
-        # Arrange
-
-        # Act
-        result = JsonSerializer.encode_unit(value)
-
-        # Assert
-        assert result == expected
-
-
 def test_round_trip(tmp_path: pathlib.Path):
     """Test that a serialized and then deserialized dictionary is unchanged."""
 

--- a/tests/test_serializers/test_json.py
+++ b/tests/test_serializers/test_json.py
@@ -18,7 +18,7 @@ from snappiershot.serializers.json import JsonDeserializer, JsonSerializer
 
 
 class TestNumericEncoding:
-    """ Tests for custom encoding of numeric types. """
+    """Tests for custom encoding of numeric types."""
 
     NUMERIC_DECODING_TEST_CASES = [
         (3 + 4j, CustomEncodedNumericTypes.complex.json_encoding([3, 4])),
@@ -46,7 +46,7 @@ class TestNumericEncoding:
     @staticmethod
     @pytest.mark.parametrize("value, expected", NUMERIC_ENCODING_TEST_CASES)
     def test_encode_numeric(value, expected):
-        """ Test that the JsonSerializer.encode_numeric encodes values as expected. """
+        """Test that the JsonSerializer.encode_numeric encodes values as expected."""
         # Arrange
 
         # Act
@@ -57,7 +57,7 @@ class TestNumericEncoding:
 
     @staticmethod
     def test_encode_numeric_error():
-        """ Test that the JsonSerializer.encode_numeric raises an error if no encoding is defined. """
+        """Test that the JsonSerializer.encode_numeric raises an error if no encoding is defined."""
         # Arrange
         value = "3.121"
 
@@ -68,7 +68,7 @@ class TestNumericEncoding:
     @staticmethod
     @pytest.mark.parametrize("expected, value", NUMERIC_DECODING_TEST_CASES)
     def test_decode_numeric(expected, value):
-        """ Test that the JsonDeserializer.decode_numeric decodes values as expected. """
+        """Test that the JsonDeserializer.decode_numeric decodes values as expected."""
         # Arrange
 
         # Act
@@ -79,7 +79,7 @@ class TestNumericEncoding:
 
     @staticmethod
     def test_decode_numeric_error():
-        """ Test that the JsonDeserializer.decode_numeric raises an error if no decoding is defined. """
+        """Test that the JsonDeserializer.decode_numeric raises an error if no decoding is defined."""
         # Arrange
         value = {"numeric": "decimal", "value": "3.14"}
 
@@ -89,7 +89,7 @@ class TestNumericEncoding:
 
 
 class TestDatetimeEncoding:
-    """ Tests for custom encoding of datetime types. """
+    """Tests for custom encoding of datetime types."""
 
     DATETIME_DECODING_TEST_CASES = [
         # fmt: off
@@ -111,7 +111,7 @@ class TestDatetimeEncoding:
     @staticmethod
     @pytest.mark.parametrize("value, expected", DATETIME_ENCODING_TEST_CASES)
     def test_encode_datetime(value, expected):
-        """ Test that the JsonSerializer.encode_datetime encodes values as expected. """
+        """Test that the JsonSerializer.encode_datetime encodes values as expected."""
         # Arrange
 
         # Act
@@ -122,7 +122,7 @@ class TestDatetimeEncoding:
 
     @staticmethod
     def test_encode_datetime_error():
-        """ Test that the JsonSerializer.encode_datetime raises an error if no encoding is defined. """
+        """Test that the JsonSerializer.encode_datetime raises an error if no encoding is defined."""
         # Arrange
         value = "not a datetime"
 
@@ -133,7 +133,7 @@ class TestDatetimeEncoding:
     @staticmethod
     @pytest.mark.parametrize("expected, value", DATETIME_DECODING_TEST_CASES)
     def test_decode_datetime(value, expected):
-        """ Test that the JsonDeserializer.decode_datetime decodes values as expected. """
+        """Test that the JsonDeserializer.decode_datetime decodes values as expected."""
         # Arrange
 
         # Act
@@ -144,7 +144,7 @@ class TestDatetimeEncoding:
 
     @staticmethod
     def test_decode_datetime_error():
-        """ Test that the JsonDeserializer.decode_datetime raises an error if no decoding is defined. """
+        """Test that the JsonDeserializer.decode_datetime raises an error if no decoding is defined."""
         # Arrange
         value = {"foo": "bar"}
 
@@ -154,12 +154,15 @@ class TestDatetimeEncoding:
 
 
 class TestCollectionEncoding:
-    """ Tests for custom encoding of collection types. """
+    """Tests for custom encoding of collection types."""
 
     COLLECTION_DECODING_TEST_CASES = [
         ({1, 2, 3}, CustomEncodedCollectionTypes.set.json_encoding([1, 2, 3])),
         ((1, 2, 3), CustomEncodedCollectionTypes.tuple.json_encoding([1, 2, 3])),
-        (b"\x01\x02\x03", CustomEncodedCollectionTypes.bytes.json_encoding([1, 2, 3]),),
+        (
+            b"\x01\x02\x03",
+            CustomEncodedCollectionTypes.bytes.json_encoding([1, 2, 3]),
+        ),
     ]
 
     COLLECTION_ENCODING_TEST_CASES = [
@@ -169,7 +172,7 @@ class TestCollectionEncoding:
 
     @staticmethod
     def test_encode_collection_error():
-        """ Test that the JsonSerializer.encode_collection raises an error if no encoding is defined. """
+        """Test that the JsonSerializer.encode_collection raises an error if no encoding is defined."""
         # Arrange
         value = bytearray(10)
 
@@ -180,7 +183,7 @@ class TestCollectionEncoding:
     @staticmethod
     @pytest.mark.parametrize("value, expected", COLLECTION_ENCODING_TEST_CASES)
     def test_encode_collection(value, expected):
-        """ Test that the JsonSerializer.encode_collection encodes values as expected. """
+        """Test that the JsonSerializer.encode_collection encodes values as expected."""
         # Arrange
 
         # Act
@@ -192,7 +195,7 @@ class TestCollectionEncoding:
     @staticmethod
     @pytest.mark.parametrize("expected, value", COLLECTION_DECODING_TEST_CASES)
     def test_decode_collection(value, expected):
-        """ Test that the JsonDeserializer.decode_collection decodes collections as expected. """
+        """Test that the JsonDeserializer.decode_collection decodes collections as expected."""
         # Arrange
 
         # Act
@@ -203,7 +206,7 @@ class TestCollectionEncoding:
 
     @staticmethod
     def test_decode_collection_error():
-        """ Test that the JsonDeserializer.decode_collection raises an error if no decoding is defined. """
+        """Test that the JsonDeserializer.decode_collection raises an error if no decoding is defined."""
         # Arrange
         value = {"foo": "bar"}
 
@@ -213,7 +216,7 @@ class TestCollectionEncoding:
 
 
 class TestPathEncoding:
-    """ Tests for custom encoding of Path types. """
+    """Tests for custom encoding of Path types."""
 
     PATH_DECODING_TEST_CASES = [
         (
@@ -257,7 +260,7 @@ class TestPathEncoding:
     @staticmethod
     @pytest.mark.parametrize("value", PATH_ENCODING_UNSUPPORTED_CASES)
     def test_encode_path_error(value):
-        """ Test that the JsonSerializer.encode_path raises an error if no encoding is defined. """
+        """Test that the JsonSerializer.encode_path raises an error if no encoding is defined."""
         # Arrange
         value = b"foobar"
 
@@ -268,7 +271,7 @@ class TestPathEncoding:
     @staticmethod
     @pytest.mark.parametrize("value, expected", PATH_ENCODING_TEST_CASES)
     def test_encode_path(value, expected):
-        """ Test that the JsonSerializer.encode_path encodes values as expected. """
+        """Test that the JsonSerializer.encode_path encodes values as expected."""
         # Arrange
 
         # Act
@@ -280,7 +283,7 @@ class TestPathEncoding:
     @staticmethod
     @pytest.mark.parametrize("expected, value", PATH_DECODING_TEST_CASES)
     def test_decode_path(value, expected):
-        """ Test that the JsonDeserializer.decode_path decodes collections as expected. """
+        """Test that the JsonDeserializer.decode_path decodes collections as expected."""
         # Arrange
 
         # Act
@@ -291,7 +294,7 @@ class TestPathEncoding:
 
     @staticmethod
     def test_decode_path_error():
-        """ Test that the JsonDeserializer.decode_path raises an error if no decoding is defined. """
+        """Test that the JsonDeserializer.decode_path raises an error if no decoding is defined."""
         # Arrange
         value = {"foo": "bar"}
 
@@ -301,17 +304,20 @@ class TestPathEncoding:
 
 
 class TestUnitEncoding:
-    """ Tests for custom encoding of Unit types from pint. """
+    """Tests for custom encoding of Unit types from pint."""
 
     UNIT_DECODING_TEST_CASES = [
-        (Unit("meter"), CustomEncodedUnitTypes.unit.json_encoding("meter"),),
+        (
+            Unit("meter"),
+            CustomEncodedUnitTypes.unit.json_encoding("meter"),
+        ),
     ]
 
     UNIT_ENCODING_TEST_CASES = UNIT_DECODING_TEST_CASES
 
     @staticmethod
     def test_encode_unit_error():
-        """ Test that the JsonSerializer.encode_unit raises an error if no encoding is defined. """
+        """Test that the JsonSerializer.encode_unit raises an error if no encoding is defined."""
         # Arrange
         value = "foo"
 
@@ -322,7 +328,7 @@ class TestUnitEncoding:
     @staticmethod
     @pytest.mark.parametrize("value, expected", UNIT_ENCODING_TEST_CASES)
     def test_encode_unit(value, expected):
-        """ Test that the JsonSerializer.encode_unit encodes values as expected. """
+        """Test that the JsonSerializer.encode_unit encodes values as expected."""
         # Arrange
 
         # Act
@@ -334,7 +340,7 @@ class TestUnitEncoding:
     @staticmethod
     @pytest.mark.parametrize("expected, value", UNIT_DECODING_TEST_CASES)
     def test_decode_unit(value, expected):
-        """ Test that the JsonDeserializer.decode_unit decodes Units as expected. """
+        """Test that the JsonDeserializer.decode_unit decodes Units as expected."""
         # Arrange
 
         # Act
@@ -345,7 +351,7 @@ class TestUnitEncoding:
 
     @staticmethod
     def test_decode_unit_error():
-        """ Test that the JsonDeserializer.decode_unit raises an error if no decoding is defined. """
+        """Test that the JsonDeserializer.decode_unit raises an error if no decoding is defined."""
         # Arrange
         value = {"foo": "bar"}
 
@@ -355,16 +361,19 @@ class TestUnitEncoding:
 
 
 class TestUninstantiatedClassEncoding:
-    """ Tests for custom encoding of special classes that haven't been instantiated. """
+    """Tests for custom encoding of special classes that haven't been instantiated."""
 
     DECODING_TEST_CASES = [
-        (Unit("meter"), CustomEncodedUnitTypes.unit.json_encoding("meter"),),
+        (
+            Unit("meter"),
+            CustomEncodedUnitTypes.unit.json_encoding("meter"),
+        ),
     ]
 
     @staticmethod
     @pytest.mark.parametrize("value, expected", DECODING_TEST_CASES)
     def test_encode_uninstantiated_class(value, expected):
-        """ Test that the JsonSerializer.default encodes special uninstantiated classes as expected. """
+        """Test that the JsonSerializer.default encodes special uninstantiated classes as expected."""
         # Arrange
 
         # Act
@@ -375,7 +384,7 @@ class TestUninstantiatedClassEncoding:
 
 
 def test_round_trip(tmp_path: pathlib.Path):
-    """ Test that a serialized and then deserialized dictionary is unchanged. """
+    """Test that a serialized and then deserialized dictionary is unchanged."""
     # Define a random class with skip methods
     class ClassWithSkip:
         def __init__(self):

--- a/tests/test_serializers/test_json.py
+++ b/tests/test_serializers/test_json.py
@@ -385,14 +385,6 @@ class TestUninstantiatedClassEncoding:
 
 def test_round_trip(tmp_path: pathlib.Path):
     """Test that a serialized and then deserialized dictionary is unchanged."""
-    # Define a random class with skip methods
-    class ClassWithSkip:
-        def __init__(self):
-            self.a = 1
-            self.b = 2
-
-        def __snapshot__(self):
-            return "Skip Me"
 
     # Arrange
     data = {

--- a/tests/test_serializers/test_json.py
+++ b/tests/test_serializers/test_json.py
@@ -306,15 +306,6 @@ class TestPathEncoding:
 class TestUnitEncoding:
     """Tests for custom encoding of Unit types from pint."""
 
-    UNIT_DECODING_TEST_CASES = [
-        (
-            Unit("meter"),
-            CustomEncodedUnitTypes.unit.json_encoding("meter"),
-        ),
-    ]
-
-    UNIT_ENCODING_TEST_CASES = UNIT_DECODING_TEST_CASES
-
     @staticmethod
     def test_encode_unit_error():
         """Test that the JsonSerializer.encode_unit raises an error if no encoding is defined."""
@@ -326,10 +317,11 @@ class TestUnitEncoding:
             JsonSerializer.encode_unit(value)
 
     @staticmethod
-    @pytest.mark.parametrize("value, expected", UNIT_ENCODING_TEST_CASES)
-    def test_encode_unit(value, expected):
+    def test_encode_unit():
         """Test that the JsonSerializer.encode_unit encodes values as expected."""
         # Arrange
+        value = Unit("meter")
+        expected = CustomEncodedUnitTypes.unit.json_encoding("meter")
 
         # Act
         result = JsonSerializer.encode_unit(value)
@@ -338,10 +330,11 @@ class TestUnitEncoding:
         assert result == expected
 
     @staticmethod
-    @pytest.mark.parametrize("expected, value", UNIT_DECODING_TEST_CASES)
-    def test_decode_unit(value, expected):
+    def test_decode_unit():
         """Test that the JsonDeserializer.decode_unit decodes Units as expected."""
         # Arrange
+        expected = Unit("meter")
+        value = CustomEncodedUnitTypes.unit.json_encoding("meter")
 
         # Act
         result = JsonDeserializer.decode_unit(value)

--- a/tests/test_serializers/test_json.py
+++ b/tests/test_serializers/test_json.py
@@ -391,7 +391,7 @@ def test_round_trip(tmp_path: pathlib.Path):
             return "Skip Me"
 
         @classmethod
-        def __snapshotskip__(cls):
+        def __metadata_override__(cls):
             return "Skip Me"
 
     # Arrange

--- a/tests/test_serializers/test_optional_module_utils.py
+++ b/tests/test_serializers/test_optional_module_utils.py
@@ -88,7 +88,7 @@ class TestPandas:
 
     @staticmethod
     def test_encode_pandas_error():
-        """ Test that the encode_pandas raises an error if no encoding is defined. """
+        """Test that the encode_pandas raises an error if no encoding is defined."""
         # Arrange
         value = "not a pandas"
 
@@ -173,7 +173,7 @@ class TestNumpy:
 
     @staticmethod
     def test_encode_numpy_error():
-        """ Test that the encode_numpy raises an error if no encoding is defined. """
+        """Test that the encode_numpy raises an error if no encoding is defined."""
         # Arrange
         value = "not a numpy"
 

--- a/tests/test_serializers/test_utils.py
+++ b/tests/test_serializers/test_utils.py
@@ -13,11 +13,11 @@ from snappiershot.serializers.utils import (
 
 
 class TestDefaultEncodeValue:
-    """ Tests for the default_encode_value utility function. """
+    """Tests for the default_encode_value utility function."""
 
     @staticmethod
     def test_encode_class():
-        """ Test that a class is encoded as expected. """
+        """Test that a class is encoded as expected."""
         # Arrange
         value = SimpleNamespace(a=1, b="banana", c=None)
         expected = dict(a=1, b="banana", c=None)
@@ -30,7 +30,7 @@ class TestDefaultEncodeValue:
 
     @staticmethod
     def test_encode_class_recursive():
-        """ Test that a class is recursively encoded as expected. """
+        """Test that a class is recursively encoded as expected."""
         # Arrange
         value = SimpleNamespace(
             class_=SimpleNamespace(a=1, b="banana", c=None),
@@ -51,18 +51,18 @@ class TestDefaultEncodeValue:
 
     @staticmethod
     def test_encode_custom_encoder():
-        """ Test that a class that specifies a custom encoder
+        """Test that a class that specifies a custom encoder
         gets encoded using that method.
         """
         # Arrange
         encoding = "CUSTOM ENCODING"
 
         class ClassWithCustomEncoder:
-            """ Example class with custom encoder. """
+            """Example class with custom encoder."""
 
             # noinspection PyMethodMayBeStatic
             def __snapshot__(self):
-                """ Custom encoder for snappiershot. """
+                """Custom encoder for snappiershot."""
                 return encoding
 
         value = ClassWithCustomEncoder()
@@ -75,7 +75,7 @@ class TestDefaultEncodeValue:
 
     @staticmethod
     def test_encode_serializable_types():
-        """ Test that a class with custom-encoded types does not encode these types. """
+        """Test that a class with custom-encoded types does not encode these types."""
         # Arrange
         from datetime import datetime
 
@@ -93,7 +93,7 @@ class TestDefaultEncodeValue:
     @staticmethod
     @pytest.mark.parametrize("value", (set("abcdefg"), (1, 2, 3)))
     def test_encode_collection_types(value):
-        """ Test that a class with custom-encoded types does not encode collection. """
+        """Test that a class with custom-encoded types does not encode collection."""
         # Arrange
 
         # Act
@@ -105,7 +105,7 @@ class TestDefaultEncodeValue:
     @staticmethod
     @pytest.mark.parametrize("value", [isinstance, type, iter([1, 2])])
     def test_encode_unserializable(value):
-        """ Test that an unserializable object raises an error. """
+        """Test that an unserializable object raises an error."""
         # Arrange
 
         # Act & Assert
@@ -114,7 +114,7 @@ class TestDefaultEncodeValue:
 
     @staticmethod
     def test_encode_unserializable_recurse():
-        """ Test that a class with un-serializable attributes does not error. """
+        """Test that a class with un-serializable attributes does not error."""
         # Arrange
         value = SimpleNamespace(
             class_=SimpleNamespace(good="class", bad=type),
@@ -131,7 +131,7 @@ class TestDefaultEncodeValue:
 
     @staticmethod
     def test_encode_recursive_object():
-        """ Test that recursive objects are handled gracefully. """
+        """Test that recursive objects are handled gracefully."""
         # Arrange
         value = SimpleNamespace(class_=None, dict_=None, list_=None)
         value.class_ = value
@@ -200,7 +200,7 @@ class TestDefaultEncodeValue:
 
     @staticmethod
     def test_slots_class():
-        """ Test default encoding of recursive slots-optimized classes. """
+        """Test default encoding of recursive slots-optimized classes."""
         # Arrange
         class SlotsClass:
             __slots__ = ("a", "b", "c", "d")
@@ -220,11 +220,11 @@ class TestDefaultEncodeValue:
 
 
 class TestGetSnapshotFile:
-    """ Tests for the get_snapshot_file utility function. """
+    """Tests for the get_snapshot_file utility function."""
 
     @staticmethod
     def test_get_snapshot_file(tmp_path):
-        """ Test that get_snapshot_file returns the expected path. """
+        """Test that get_snapshot_file returns the expected path."""
         # Arrange
         test_file = tmp_path / "example_test.py"
         suffix = ".json"
@@ -239,7 +239,7 @@ class TestGetSnapshotFile:
 
     @staticmethod
     def test_get_snapshot_file_directory_error(tmp_path):
-        """ Test that get_snapshot_file raises an error if the directory
+        """Test that get_snapshot_file raises an error if the directory
         containing the test does not exist.
         """
         # Arrange
@@ -252,7 +252,7 @@ class TestGetSnapshotFile:
 
     @staticmethod
     def test_get_snapshot_file_type_error(tmp_path):
-        """ Test that get_snapshot_file raises an error for an invalid suffix. """
+        """Test that get_snapshot_file raises an error for an invalid suffix."""
         # Arrange
         test_file = tmp_path / "example_test.py"
         suffix = "json"
@@ -263,7 +263,7 @@ class TestGetSnapshotFile:
 
 
 class TestEncodingExceptions:
-    """ Tests for exception encoding. """
+    """Tests for exception encoding."""
 
     @staticmethod
     @pytest.mark.parametrize(
@@ -279,7 +279,7 @@ class TestEncodingExceptions:
         # fmt: on
     )
     def test_write_json_error(value, expected):
-        """ Test if an error occurs during snapshot writing, no file is written. """
+        """Test if an error occurs during snapshot writing, no file is written."""
         # Arrange
 
         # Act
@@ -290,11 +290,11 @@ class TestEncodingExceptions:
 
 
 class TestFullVars:
-    """ Tests for the fullvars. """
+    """Tests for the fullvars."""
 
     @staticmethod
     def test_regular_class():
-        """ Test that fullvars works for a regular class. """
+        """Test that fullvars works for a regular class."""
         # Arrange
         class NormalClass:
             def __init__(self):
@@ -312,7 +312,7 @@ class TestFullVars:
 
     @staticmethod
     def test_slots_class():
-        """ Test that fullvars works for a slots-optimized class. """
+        """Test that fullvars works for a slots-optimized class."""
         # Arrange
         class SlotsClass:
             __slots__ = ("a", "b", "c")
@@ -332,8 +332,8 @@ class TestFullVars:
 
     @staticmethod
     def test_slots_class_partial_instantiated():
-        """ Test that fullvars works for a slots-optimized class
-        with partially instantiated slots. """
+        """Test that fullvars works for a slots-optimized class
+        with partially instantiated slots."""
         # Arrange
         class SlotsClassPartiallyInstantiated:
             __slots__ = ("a", "b", "c")
@@ -352,7 +352,7 @@ class TestFullVars:
 
     @staticmethod
     def test_mixed_class():
-        """ Test that fullvars works for classes with __slots__ and __dict__. """
+        """Test that fullvars works for classes with __slots__ and __dict__."""
         # Arrange
         class MixedClass:
             __slots__ = ("__dict__", "a", "b")
@@ -372,7 +372,7 @@ class TestFullVars:
 
     @staticmethod
     def test_empty_class():
-        """ Test that fullvars works for an empty class. """
+        """Test that fullvars works for an empty class."""
         # Arrange
         class EmptyClass:
             pass
@@ -387,7 +387,7 @@ class TestFullVars:
 
     @staticmethod
     def test_to_dict_class():
-        """ Test that fullvars works for classes with to_dict. """
+        """Test that fullvars works for classes with to_dict."""
         # Arrange
         class ToDictClass:
             def __init__(self):

--- a/tests/test_serializers/test_utils.py
+++ b/tests/test_serializers/test_utils.py
@@ -218,6 +218,28 @@ class TestDefaultEncodeValue:
         # Assert
         assert result == dict(a=1, b=2)
 
+    @staticmethod
+    def test_uninstantiated_class():
+        """ Test encoding for uninstantiated classes with a special skip function defined """
+
+        # Arrange
+        class UninstantiatedClass:
+            def __init__(self):
+                self.a = 1
+                self.b = 2
+                self.c = 3
+
+            @classmethod
+            def __snapshotskip__(cls):
+                encoding = "Dont Encode Me!"
+                return encoding
+
+        # Act
+        result = default_encode_value(UninstantiatedClass)
+
+        # Assert
+        assert result == "Dont Encode Me!"
+
 
 class TestGetSnapshotFile:
     """ Tests for the get_snapshot_file utility function. """
@@ -384,3 +406,24 @@ class TestFullVars:
 
         # Assert
         assert result == dict()
+
+    @staticmethod
+    def test_to_dict_class():
+        """ Test that fullvars works for classes with to_dict. """
+        # Arrange
+        class ToDictClass:
+            def __init__(self):
+                self.a = 1
+                self.b = 2
+                self.c = 3
+
+            def to_dict(self):
+                return getattr(self, "__dict__", dict())
+
+        klass = ToDictClass()
+
+        # Act
+        result = fullvars(klass)
+
+        # Assert
+        assert result == dict(a=1, b=2, c=3)

--- a/tests/test_serializers/test_utils.py
+++ b/tests/test_serializers/test_utils.py
@@ -218,28 +218,6 @@ class TestDefaultEncodeValue:
         # Assert
         assert result == dict(a=1, b=2)
 
-    @staticmethod
-    def test_uninstantiated_class():
-        """ Test encoding for uninstantiated classes with a special skip function defined """
-
-        # Arrange
-        class UninstantiatedClass:
-            def __init__(self):
-                self.a = 1
-                self.b = 2
-                self.c = 3
-
-            @classmethod
-            def __metadata_override__(cls):
-                encoding = "Dont Encode Me!"
-                return encoding
-
-        # Act
-        result = default_encode_value(UninstantiatedClass)
-
-        # Assert
-        assert result == "Dont Encode Me!"
-
 
 class TestGetSnapshotFile:
     """ Tests for the get_snapshot_file utility function. """

--- a/tests/test_serializers/test_utils.py
+++ b/tests/test_serializers/test_utils.py
@@ -230,7 +230,7 @@ class TestDefaultEncodeValue:
                 self.c = 3
 
             @classmethod
-            def __snapshotskip__(cls):
+            def __metadata_override__(cls):
                 encoding = "Dont Encode Me!"
                 return encoding
 

--- a/tests/test_snapshot/conftest.py
+++ b/tests/test_snapshot/conftest.py
@@ -12,13 +12,13 @@ from snappiershot.snapshot.snapshot import Snapshot
 
 @pytest.fixture(name="config")
 def _config() -> Config:
-    """ Construct a default Config object to be used for all tests. """
+    """Construct a default Config object to be used for all tests."""
     return Config()
 
 
 @pytest.fixture(name="empty_caller_info")
 def _empty_caller_info(tmp_path: Path, mocker: MockerFixture) -> CallerInfo:
-    """ Mocks the call to the "from_call_stack" method of snappiershot.inspection.CallerInfo.
+    """Mocks the call to the "from_call_stack" method of snappiershot.inspection.CallerInfo.
 
     The method returns an CallerInfo object that contains no arguments.
     """
@@ -32,13 +32,13 @@ def _empty_caller_info(tmp_path: Path, mocker: MockerFixture) -> CallerInfo:
 
 @pytest.fixture(name="metadata")
 def _metadata(empty_caller_info: CallerInfo) -> SnapshotMetadata:
-    """ Construct a default SnapshotMetadata object. """
+    """Construct a default SnapshotMetadata object."""
     return SnapshotMetadata(empty_caller_info, update_on_next_run=False)
 
 
 @pytest.fixture(name="snapshot_file")
 def _snapshot_file(tmp_path: Path, mocker: MockerFixture) -> Path:
-    """ Mocks the call to the snappiershot.serializers.utils.get_snapshot_file. """
+    """Mocks the call to the snappiershot.serializers.utils.get_snapshot_file."""
     snapshot_file = tmp_path.joinpath("snapshot.json")
     mocker.patch(
         "snappiershot.snapshot._file.get_snapshot_file", return_value=snapshot_file
@@ -49,7 +49,7 @@ def _snapshot_file(tmp_path: Path, mocker: MockerFixture) -> Path:
 @pytest.fixture(name="snapshot")
 @pytest.mark.usefixtures("snapshot_file")
 def _snapshot(config: Config, metadata: SnapshotMetadata) -> Snapshot:
-    """ Returns a snappiershot.snapshot.Snapshot object with preset
+    """Returns a snappiershot.snapshot.Snapshot object with preset
     _metadata and _snapshot_file attributes.
     """
     snapshot = Snapshot()

--- a/tests/test_snapshot/test_file.py
+++ b/tests/test_snapshot/test_file.py
@@ -14,11 +14,11 @@ from snappiershot.snapshot.status import SnapshotStatus
 
 @pytest.mark.usefixtures("empty_caller_info", "snapshot_file")
 class TestSnapshotFile:
-    """ Tests for the snappiershot.snapshot._SnapshotFile object. """
+    """Tests for the snappiershot.snapshot._SnapshotFile object."""
 
     @staticmethod
     def test_get_snapshot_file_error(config: Config, metadata: SnapshotMetadata):
-        """ Test that _SnapshotFile._get_snapshot_file raises an error when given an
+        """Test that _SnapshotFile._get_snapshot_file raises an error when given an
         unsupported file format.
         """
         # Arrange
@@ -33,7 +33,7 @@ class TestSnapshotFile:
 
     @staticmethod
     def test_parse_snapshot_file_no_file(config: Config, metadata: SnapshotMetadata):
-        """ Test that if the snapshot file does not exist, the file contents are set to
+        """Test that if the snapshot file does not exist, the file contents are set to
         an empty, default value.
         """
         # Arrange
@@ -116,7 +116,7 @@ class TestSnapshotFile:
         metadata: SnapshotMetadata,
         snapshot_file: Path,
     ):
-        """ Test that the _SnapshotFile._find_snapshots method finds snapshots as expected
+        """Test that the _SnapshotFile._find_snapshots method finds snapshots as expected
         and updates the _file_contents attribute as expected.
         """
         # Arrange
@@ -137,7 +137,7 @@ class TestSnapshotFile:
     def test_get_snapshot(
         snapshots, index, expected, config: Config, metadata: SnapshotMetadata
     ):
-        """ Test that the _SnapshotFile.get_snapshot method functions as expected.
+        """Test that the _SnapshotFile.get_snapshot method functions as expected.
 
         Additionally assert that no changes are flagged from reading snapshots.
         """
@@ -153,7 +153,7 @@ class TestSnapshotFile:
         assert not snapshot_file._changed_flag
 
     def test_mark_failed(self, config: Config, metadata: SnapshotMetadata):
-        """ Test that the _SnapshotFile.mark_failed method functions as expected. """
+        """Test that the _SnapshotFile.mark_failed method functions as expected."""
         # Arrange
         snapshot_file = _SnapshotFile(config, metadata)
         expected = [SnapshotStatus.FAILED]
@@ -165,7 +165,7 @@ class TestSnapshotFile:
         assert snapshot_file._snapshot_statuses == expected
 
     def test_mark_passed(self, config: Config, metadata: SnapshotMetadata):
-        """ Test that the _SnapshotFile.mark_passed method functions as expected. """
+        """Test that the _SnapshotFile.mark_passed method functions as expected."""
         # Arrange
         snapshot_file = _SnapshotFile(config, metadata)
         expected = [SnapshotStatus.PASSED]
@@ -178,7 +178,7 @@ class TestSnapshotFile:
 
     @staticmethod
     def test_record_snapshot(config: Config, metadata: SnapshotMetadata):
-        """ Test that the _SnapshotFile.record_snapshot method functions as expected.
+        """Test that the _SnapshotFile.record_snapshot method functions as expected.
 
         Additionally assert that changes are flagged when recording snapshots.
         """
@@ -205,7 +205,7 @@ class TestSnapshotFile:
         metadata: SnapshotMetadata,
         snapshot_file: Path,
     ):
-        """ Test that the write method only writes when a changes are flagged. """
+        """Test that the write method only writes when a changes are flagged."""
         # Arrange
         snapshot_file_object = _SnapshotFile(config, metadata)
         snapshot_file_object._changed_flag = changed_flag
@@ -225,7 +225,7 @@ class TestSnapshotFile:
 
     @staticmethod
     def test_encoded_metadata(config: Config, snapshot_file: Path):
-        """ Test that SnapshotMetadata gets encoded to eliminate serialization errors. """
+        """Test that SnapshotMetadata gets encoded to eliminate serialization errors."""
         # Arrange
         args = dict(unhandled_type=SimpleNamespace(complex=3 + 4j))
         caller_info = CallerInfo(snapshot_file, "test_function", args)

--- a/tests/test_snapshot/test_metadata.py
+++ b/tests/test_snapshot/test_metadata.py
@@ -35,7 +35,7 @@ class TestSnapshotMetadata:
             self.test2 = 2
 
         @classmethod
-        def __snapshotskip__(cls):
+        def __metadata_override__(cls):
             return "Skip Me"
 
     FAKE_CALLER_INFO = CallerInfo(

--- a/tests/test_snapshot/test_metadata.py
+++ b/tests/test_snapshot/test_metadata.py
@@ -26,7 +26,14 @@ class TestSnapshotMetadata:
     FAKE_CALLER_INFO = CallerInfo(
         file=Path("fake/file/path"),
         function="fake_fully_qualified_function_name",
-        args={"foo": 1, "bar": "two", "foobar": [1, 2], "barfoo": array([1, 2])},
+        args={
+            "foo": 1,
+            "bar": "two",
+            "foobar": [1, 2],
+            "barfoo": array([1, 2]),
+            "foofoo": {"foo": 1, "bar": 2},
+            "barbar": [{"foo": 1, "bar": 2}, {1, 2}, (1, 2)],
+        },
     )
 
     FAKE_CALLER_INFO_CLASS = CallerInfo(
@@ -74,12 +81,30 @@ class TestSnapshotMetadata:
             (DEFAULT_METADATA_KWARGS, {"arguments": FAKE_CALLER_INFO.args}, True),
             (
                 DEFAULT_METADATA_KWARGS,
-                {"arguments": {"foo": 1, "bar": 2, "foobar": [1, 2], "barfoo": [1, 2]}},
+                {
+                    "arguments": {
+                        "foo": 1,
+                        "bar": 2,
+                        "foobar": [1, 2],
+                        "barfoo": [1, 2],
+                        "foofoo": {"foo": 1, "bar": 2},
+                        "barbar": [{"foo": 1, "bar": 2}, {1, 2}, (1, 2)],
+                    }
+                },
                 False,
             ),
             (
                 DEFAULT_METADATA_KWARGS,
-                {"arguments": {"foo": 1, "bar": "two", "foobar": [1, 2], "barfoo": [1, 2]}},
+                {
+                    "arguments": {
+                        "foo": 1,
+                        "bar": "two",
+                        "foobar": [1, 2],
+                        "barfoo": [1, 2],
+                        "foofoo": {"foo": 1, "bar": 2},
+                        "barbar": [{"foo": 1, "bar": 2}, {1, 2}, (1, 2)],
+                    }
+                },
                 True,
             ),
             (
@@ -90,6 +115,8 @@ class TestSnapshotMetadata:
                         "bar": "two",
                         "foobar": array([1, 2]),
                         "barfoo": array([1, 2]),
+                        "foofoo": {"foo": 1, "bar": 2},
+                        "barbar": [{"foo": 1, "bar": 2}, {1, 2}, (1, 2)],
                     }
                 },
                 True,
@@ -102,6 +129,64 @@ class TestSnapshotMetadata:
                         "bar": "two",
                         "foobar": [1, "two"],
                         "barfoo": [1, 2],
+                        "foofoo": {"foo": 1, "bar": 2},
+                        "barbar": [{"foo": 1, "bar": 2}, {1, 2}, (1, 2)],
+                    }
+                },
+                False,
+            ),
+            (
+                DEFAULT_METADATA_KWARGS,
+                {
+                    "arguments": {
+                        "foo": 1,
+                        "bar": "two",
+                        "foobar": array([1, 2]),
+                        "barfoo": array([1, 2]),
+                        "foofoo": {"foo": 1, "foobar": 2},
+                        "barbar": [{"foo": 1, "bar": 2}, {1, 2}, (1, 2)],
+                    }
+                },
+                False,
+            ),
+            (
+                DEFAULT_METADATA_KWARGS,
+                {
+                    "arguments": {
+                        "foo": 1,
+                        "bar": "two",
+                        "foobar": array([1, 2]),
+                        "barfoo": array([1, 2]),
+                        "foofoo": {"foo": 1, "bar": 2},
+                        "barbar": [{"foo": 1, "foobar": 2}, {1, 2}, (1, 2)],
+                    }
+                },
+                False,
+            ),
+            (
+                DEFAULT_METADATA_KWARGS,
+                {
+                    "arguments": {
+                        "foo": 1,
+                        "bar": "two",
+                        "foobar": array([1, 2]),
+                        "barfoo": array([1, 2]),
+                        "foofoo": {"foo": 1, "bar": 2},
+                        "barbar": [{"foo": 1, "bar": 2}, {1, "2"}, (1, 2)],
+                    }
+                },
+                False,
+            ),
+            (
+                DEFAULT_METADATA_KWARGS,
+                {
+                    "arguments": {
+                        "foo": 1,
+                        "bar": "two",
+                        "foobar": array([1, 2]),
+                        "barfoo": array([1, 2]),
+                        "foofoo": {"foo": 1, "bar": 2},
+                        "barbar": [{"foo": 1, "bar": 2}, {1, 2}, (1, "2")],
                     }
                 },
                 False,

--- a/tests/test_snapshot/test_metadata.py
+++ b/tests/test_snapshot/test_metadata.py
@@ -9,7 +9,7 @@ from snappiershot.snapshot.metadata import SnapshotMetadata
 
 
 class TestSnapshotMetadata:
-    """ Tests for the snappiershot.snapshot.SnapshotMetadata object. """
+    """Tests for the snappiershot.snapshot.SnapshotMetadata object."""
 
     # Define a complicated class
     class ToDictClass:
@@ -60,7 +60,7 @@ class TestSnapshotMetadata:
         ],
     )
     def test_metadata_validate(metadata_kwargs: Dict, expected_error: Type[Exception]):
-        """ Checks that validation of the metadata values occurs as expected. """
+        """Checks that validation of the metadata values occurs as expected."""
         # Arrange
 
         # Act & Assert
@@ -114,7 +114,7 @@ class TestSnapshotMetadata:
         ],
     )
     def test_metadata_matches(metadata_kwargs: Dict, metadata_dict: Dict, matches: bool):
-        """ Checks that the SnapshotMetadata.matches method functions as expected. """
+        """Checks that the SnapshotMetadata.matches method functions as expected."""
         # Arrange
         metadata = SnapshotMetadata(**metadata_kwargs)
 

--- a/tests/test_snapshot/test_raises.py
+++ b/tests/test_snapshot/test_raises.py
@@ -6,7 +6,7 @@ from snappiershot.snapshot._raises import _RaisesContext
 
 
 def test_no_exception_raised(snapshot: Snapshot):
-    """ Test that the expected error is raised when no exception is caught. """
+    """Test that the expected error is raised when no exception is caught."""
     # Arrange
     raises = _RaisesContext(snapshot, BaseException, False)
 
@@ -17,7 +17,7 @@ def test_no_exception_raised(snapshot: Snapshot):
 
 
 def test_wrong_exception_raised(snapshot: Snapshot):
-    """ Test that the expected error is raised when no exception is caught. """
+    """Test that the expected error is raised when no exception is caught."""
     # Arrange
     raises = _RaisesContext(snapshot, ValueError, False)
 

--- a/tests/test_snapshot/test_snapshot.py
+++ b/tests/test_snapshot/test_snapshot.py
@@ -10,11 +10,11 @@ from snappiershot.snapshot.snapshot import Snapshot
 
 
 class TestSnapshot:
-    """ Tests for the snappiershot.snapshot.Snapshot object. """
+    """Tests for the snappiershot.snapshot.Snapshot object."""
 
     @staticmethod
     def test_snapshot_assert(snapshot: Snapshot, mocker: MockerFixture) -> None:
-        """ Checks that snapshot assert works as expected """
+        """Checks that snapshot assert works as expected"""
         # Arrange
         # Mock stored snapshot value
         value = {"balloons": "are awesome"}
@@ -28,7 +28,7 @@ class TestSnapshot:
 
     @staticmethod
     def test_snapshot_assert_failure(snapshot: Snapshot, mocker: MockerFixture) -> None:
-        """ Checks that snapshot assert works as expected with mis-matched values"""
+        """Checks that snapshot assert works as expected with mis-matched values"""
         # Arrange
         # Mock stored snapshot value
         value = {"balloons": "are awesome"}
@@ -44,7 +44,7 @@ class TestSnapshot:
     def test_snapshot_update(
         snapshot: Snapshot, mocker: MockerFixture, warning_catcher: List[WarningMessage]
     ) -> None:
-        """ Checks that snapshot assert with update flag ON works as expected.
+        """Checks that snapshot assert with update flag ON works as expected.
 
         If "update" is flagged, then no AssertionError should be raised.
         """
@@ -65,7 +65,7 @@ class TestSnapshot:
 
     @staticmethod
     def test_construct_diff(mocker: MockerFixture):
-        """ Test that the human-readable diff is constructed as expected. """
+        """Test that the human-readable diff is constructed as expected."""
         # Arrange
         value = False
         expected = 3 + 4j
@@ -91,8 +91,8 @@ Summary:
 
     @staticmethod
     def test_not_within_context(mocker: MockerFixture):
-        """ Test that an error is raised when trying to call the `Snapshot.assert_match`
-        method outside of context. """
+        """Test that an error is raised when trying to call the `Snapshot.assert_match`
+        method outside of context."""
         # Arrange
         snapshot = Snapshot()
         # Safety mock, should not get called.
@@ -104,7 +104,7 @@ Summary:
 
     @staticmethod
     def test_raises_match(snapshot: Snapshot, mocker: MockerFixture):
-        """ Test that `Snapshot.raises` catches and snapshot exceptions as expected. """
+        """Test that `Snapshot.raises` catches and snapshot exceptions as expected."""
         # Arrange
         exception = ZeroDivisionError("Whoops")
         value = encode_exception(exception)
@@ -128,7 +128,7 @@ Summary:
         ],
     )
     def test_raises_type_errors(expected_exception, update, snapshot: Snapshot):
-        """ Test that `Snapshot.raises` rejects invalid argument types. """
+        """Test that `Snapshot.raises` rejects invalid argument types."""
         # Arrange
 
         # Act & Assert


### PR DESCRIPTION
Describe the Changes
* Added support for serializing, deserialization, encoding, decoding, and comparing the Unit class which comes from the [pint](https://pint.readthedocs.io/en/stable/) package.
* Doing so added a layer of complexity to the metadata matching functionality where the previous code base attempted comparing a dictionary of objects to a dictionary of objects that have been decomposed into their components. Thus, the second dictionary must have its values instantiated into objects for the comparison to work.
* Fixed comparison between float and float64
* Added TODO and potential code (commented out) to fix file status tracking when using ``pytest`` with ``norecursedirs``
* Added capability to ignore certain metadata arguments straight from the ``assert_match`` method

Example Code
No new additions have been made to the API.

Additional Notes
Objects with a to_dict() and from_dict() method no longer follow the behavior of similar objects with only a __dict__ or __slots__ method.

Objects of type pint.unit.Unit are assumed to be the same as objects of type pint.unit.build_unit_class.<locals>.Unit.

Specific arguments in the metadata can be skipped by adding an ``ignore=["arg", "names", "to", "ignore"]`` input to ``assert_match``.

Future Work
Figure out what to do about custom units defined by users that aren't in base pint. Object checking is currently string-based because of this.

Clean up spaghetti code I wrote for this PR.

Figure out what to do about comparing numpy arrays to lists and floats to float64. I added in hacky stuff to get that to work but there must be a better way. 

Fix bug where snappiershot reports tests unchecked when those tests are part of a ``norecursedirs`` command in ``pytest``.